### PR TITLE
Ids recipe

### DIFF
--- a/agl-kuksa/meta-kuksa/conf/layer.conf
+++ b/agl-kuksa/meta-kuksa/conf/layer.conf
@@ -31,7 +31,7 @@ IMAGE_INSTALL_append = " \
         remoteaccess \
         python3-pip \
         python3-requests \
-		direct-access-api \
+        direct-access-api \
         kuksa-hawkbit \
         email-notifier \
         wifi-conf \

--- a/agl-kuksa/meta-kuksa/conf/layer.conf
+++ b/agl-kuksa/meta-kuksa/conf/layer.conf
@@ -36,7 +36,6 @@ IMAGE_INSTALL_append = " \
         email-notifier \
         wifi-conf \
         docker \
-	netIDS \
         boost "
 
 TOOLCHAIN_TARGET_TASK_append = " \

--- a/agl-kuksa/meta-kuksa/recipes-netIDS/netIDS/netIDS.bb
+++ b/agl-kuksa/meta-kuksa/recipes-netIDS/netIDS/netIDS.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = ""
 inherit pkgconfig cmake
 SRCREV = "${AUTOREV}"
 
- DEPENDS = "python3-native, python-numpy"
+DEPENDS = "python3-native, python-numpy"
 
 SRC_URI = "git://github.com/eclipse/kuksa.invehicle.git;protocol=https" 
 SRC_URI[sha256sum] = ""


### PR DESCRIPTION
Removed netIDS recipe from kuksa-layer because the recipe is incomplete. This is only a temporary fix.
New issue created to fix this