### PR TITLE
Expecting compressed docker images now

### DIFF
--- a/kuksa-appmanager/kuksa/appmanager/hawkbit.py
+++ b/kuksa-appmanager/kuksa/appmanager/hawkbit.py
@@ -350,7 +350,7 @@ class DeploymentJob:
                 version=app['version'],
             ))
 
-            docker_app_image = app['artifacts'].get('docker-image.tar')
+            docker_app_image = app['artifacts'].get('docker-image.tar.bz2')
             if docker_app_image:
                 docker_app['image-tarball'] = docker_app_image['path']
 


### PR DESCRIPTION
Makes appmanager expecting comressed images, significantly reducing download times. 

Basically we are now searching for `docker-image.tar.bz2` instead of `docker-image.tar`
There will be a companion pull request for app-publisher


Checked it locally. @rai20 (or another volunteer :) ) please check on target and comment here, before it is merged.

Once this is deployed, it will not accept uncompressed images anymore, so make your to update your Hawkbit artifacts accordingly