### PR TITLE
Add .clang-format & run on src files in elm327-feeder and w3c-visserver

### DIFF
--- a/elm327-visdatafeeder/.clang-format
+++ b/elm327-visdatafeeder/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/elm327-visdatafeeder/include/actuatorTest.hpp
+++ b/elm327-visdatafeeder/include/actuatorTest.hpp
@@ -11,7 +11,7 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include<string>
+#include <string>
 using namespace std;
 
 void moveThrottleValve(int percent);

--- a/elm327-visdatafeeder/include/obd.hpp
+++ b/elm327-visdatafeeder/include/obd.hpp
@@ -11,7 +11,7 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include<string>
+#include <string>
 using namespace std;
 
 bool connectOBD(int timeout);

--- a/elm327-visdatafeeder/include/vssMapper.hpp
+++ b/elm327-visdatafeeder/include/vssMapper.hpp
@@ -11,8 +11,8 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include <string>
 #include <list>
+#include <string>
 
 using namespace std;
 

--- a/elm327-visdatafeeder/src/actuatorTest.cpp
+++ b/elm327-visdatafeeder/src/actuatorTest.cpp
@@ -11,38 +11,32 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include<string>
-#include <iostream>
 #include "actuatorTest.hpp"
+#include <iostream>
+#include <string>
 #include "obd.hpp"
 
 using namespace std;
 
-
-
 void moveThrottleValve(int percent) {
-  cout << "sending Throttle Request for % " << percent << endl; 
+  cout << "sending Throttle Request for % " << percent << endl;
   string command = "\r";
   switch (percent) {
+    case 25:
+      command = "08 77 19\r";
+      break;
+    case 50:
+      command = "08 77 32\r";
+      break;
 
-     case 25:
-              command = "08 77 19\r";
-              break;
-     case 50:
-              command = "08 77 32\r";
-              break;
+    case 75:
+      command = "08 77 4b\r";
+      break;
 
-     case 75: 
-              command = "08 77 4b\r";
-              break;
- 
-     case 100:
-              command = "08 77 64\r";
-              break;
-
-  }    
+    case 100:
+      command = "08 77 64\r";
+      break;
+  }
   string resp = writeMode8Data(command);
-  cout <<"Throttle cmd resp= "<< resp << endl;
+  cout << "Throttle cmd resp= " << resp << endl;
 }
-
-

--- a/elm327-visdatafeeder/src/main.cpp
+++ b/elm327-visdatafeeder/src/main.cpp
@@ -12,11 +12,11 @@
  * *****************************************************************************
  */
 
+#include <json.hpp>
+#include "actuatorTest.hpp"
 #include "client_wss.hpp"
 #include "obd.hpp"
-#include"vssMapper.hpp"
-#include "actuatorTest.hpp"
-#include <json.hpp>
+#include "vssMapper.hpp"
 
 using namespace std;
 using namespace jsoncons;
@@ -41,132 +41,124 @@ string url = "localhost:8090/vss";
 shared_ptr<WssClient::Connection> connection = NULL;
 
 void sendRequest(string command) {
-   cout << "Send << " << command <<endl;     
-   auto send_stream = make_shared<WssClient::SendStream>();
-   *send_stream << command;
-   pthread_mutex_lock (&wsMutex);  
-   connection->send(send_stream);
-   pthread_mutex_unlock (&wsMutex);  
+  cout << "Send << " << command << endl;
+  auto send_stream = make_shared<WssClient::SendStream>();
+  *send_stream << command;
+  pthread_mutex_lock(&wsMutex);
+  connection->send(send_stream);
+  pthread_mutex_unlock(&wsMutex);
 }
 
 // Thread that updates AVs on the tree.
-void* elmActualValuesRun (void* arg) {
-   connectOBD(10);
-   // Sleep 100ms.
-   usleep(100000);
-   // Punp the data into the tree.
+void* elmActualValuesRun(void* arg) {
+  connectOBD(10);
+  // Sleep 100ms.
+  usleep(100000);
+  // Punp the data into the tree.
 
-   // send Authorize request.
-   json authreq;
-   authreq["requestId"] = rand() % 99999;
-   authreq["action"]= "authorize";
-   authreq["tokens"] = string(TOKEN);
-   stringstream ss; 
-   ss << pretty_print(authreq);
-   sendRequest(ss.str());
+  // send Authorize request.
+  json authreq;
+  authreq["requestId"] = rand() % 99999;
+  authreq["action"] = "authorize";
+  authreq["tokens"] = string(TOKEN);
+  stringstream ss;
+  ss << pretty_print(authreq);
+  sendRequest(ss.str());
 
+  // Sleep 100ms.
+  usleep(100000);
 
-   // Sleep 100ms.
-   usleep(100000);
-   
-   // subsribe to throttle topic.
-   json subscibeReq;
-   subscibeReq["requestId"] = rand() % 99999;
-   subscibeReq["action"]= "subscribe";
-   subscibeReq["path"] = "Signal.Drivetrain.InternalCombustionEngine.ThrottleTest";
-   stringstream sstream; 
-   sstream << pretty_print(subscibeReq);
-   sendRequest(sstream.str());
-   
-    
-   int count = 0;
-   while(1) {
-    if( connection != NULL) {
-       // Sleep between values. Configurable as cmd line argument.
-       usleep(AVTHREADSLEEP);
-       string rpm = setRPM();
+  // subsribe to throttle topic.
+  json subscibeReq;
+  subscibeReq["requestId"] = rand() % 99999;
+  subscibeReq["action"] = "subscribe";
+  subscibeReq["path"] =
+      "Signal.Drivetrain.InternalCombustionEngine.ThrottleTest";
+  stringstream sstream;
+  sstream << pretty_print(subscibeReq);
+  sendRequest(sstream.str());
+
+  int count = 0;
+  while (1) {
+    if (connection != NULL) {
+      // Sleep between values. Configurable as cmd line argument.
+      usleep(AVTHREADSLEEP);
+      string rpm = setRPM();
 #ifdef DEBUG
-       cout << " RPM val " << rpm <<endl;
+      cout << " RPM val " << rpm << endl;
 #endif
-       if( rpm != "Error")
-          sendRequest(rpm);
-       string vSpeed = setVehicleSpeed();
+      if (rpm != "Error") sendRequest(rpm);
+      string vSpeed = setVehicleSpeed();
 #ifdef DEBUG
-       cout << " Speed val " << vSpeed <<endl;
+      cout << " Speed val " << vSpeed << endl;
 #endif
-       if( vSpeed != "Error")
-          sendRequest(vSpeed);
-       // Fuel status is updated leisurely. 
-       if( count > 200) 
-       {
-         string fuel = setFuelLevel();
+      if (vSpeed != "Error") sendRequest(vSpeed);
+      // Fuel status is updated leisurely.
+      if (count > 200) {
+        string fuel = setFuelLevel();
 #ifdef DEBUG
-         cout << " Fuel val " << rpm <<endl;
+        cout << " Fuel val " << rpm << endl;
 #endif
-         if( fuel != "Error")
-           sendRequest(fuel);
-       } // Fuel update end
+        if (fuel != "Error") sendRequest(fuel);
+      }  // Fuel update end
     } else {
-       cout << "No active connection to vis-server at the moment!"<< endl;
-       
+      cout << "No active connection to vis-server at the moment!" << endl;
     }
     count++;
   }
-   cout << "Exited the elm AVs update thread" << endl;
+  cout << "Exited the elm AVs update thread" << endl;
 }
 
 // Thread that updates the Errors ( DTCs)
 void* elmDTCRun(void* arg) {
-  
-   // Do nothing for the first 10 second.
-   usleep(10000000);
+  // Do nothing for the first 10 second.
+  usleep(10000000);
 
-   while(1) {
-    if( connection != NULL) {
-       list<string> errors = readErrors();
-       
-       int size = errors.size();
+  while (1) {
+    if (connection != NULL) {
+      list<string> errors = readErrors();
 
-       if( size > 0) {
+      int size = errors.size();
 
-          for(string err : errors) {
-             sendRequest(err);
+      if (size > 0) {
+        for (string err : errors) {
+          sendRequest(err);
 #ifdef DEBUG
-             cout << err << endl;
+          cout << err << endl;
 #endif
-          }
-       }
+        }
+      }
 
     } else {
-       cout << "No active connection to vis-server at the moment!"<<endl;
+      cout << "No active connection to vis-server at the moment!" << endl;
     }
-     // Sleep between reading DTC. Configurable as cmd line argument.
-     usleep(DTCTHREADSLEEP);
+    // Sleep between reading DTC. Configurable as cmd line argument.
+    usleep(DTCTHREADSLEEP);
   }
-   cout << "Exited the elm DTC update thread" << endl;
+  cout << "Exited the elm DTC update thread" << endl;
 }
 
 // on messages received.
 void onMessage(string message) {
 #ifdef DEBUG
-   cout << "Response >> " << message << endl;
+  cout << "Response >> " << message << endl;
 #endif
-   json msg;
-   msg = json::parse(message);
-   
-   if( !msg.has_key("value")) {
-      return;
-   } else if(msg.has_key("subscriptionId")) {
-          int percent = msg["value"].as<int>();
-          moveThrottleValve(percent);
-   } 
+  json msg;
+  msg = json::parse(message);
+
+  if (!msg.has_key("value")) {
+    return;
+  } else if (msg.has_key("subscriptionId")) {
+    int percent = msg["value"].as<int>();
+    moveThrottleValve(percent);
+  }
 }
 
-void* startWSClient(void * arg) {
+void* startWSClient(void* arg) {
+  WssClient client(url, true, "Client.pem", "Client.key", "CA.pem");
 
-  WssClient client(url , true ,"Client.pem", "Client.key","CA.pem");
-
-  client.on_message = [](shared_ptr<WssClient::Connection> connection, shared_ptr<WssClient::Message> message) {
+  client.on_message = [](shared_ptr<WssClient::Connection> connection,
+                         shared_ptr<WssClient::Message> message) {
     onMessage(message->string());
   };
 
@@ -175,59 +167,65 @@ void* startWSClient(void * arg) {
     connection = conn;
     pthread_t ELMAVRun_thread;
     /* create test run thread which updates the tree */
-    if(pthread_create(&ELMAVRun_thread, NULL, &elmActualValuesRun, NULL )) {
-      cout << "Error creating AVs update thread"<<endl;
+    if (pthread_create(&ELMAVRun_thread, NULL, &elmActualValuesRun, NULL)) {
+      cout << "Error creating AVs update thread" << endl;
       return 1;
     }
 
-     pthread_t ELMDTCRun_thread;
+    pthread_t ELMDTCRun_thread;
     /* create test run thread which updates the tree */
-    if(pthread_create(&ELMDTCRun_thread, NULL, &elmDTCRun, NULL )) {
-      cout << "Error creating DTC check thread"<<endl;
+    if (pthread_create(&ELMDTCRun_thread, NULL, &elmDTCRun, NULL)) {
+      cout << "Error creating DTC check thread" << endl;
       return 1;
     }
-    
+
   };
 
-  client.on_close = [](shared_ptr<WssClient::Connection> /*connection*/, int status, const string & /*reason*/) {
+  client.on_close = [](shared_ptr<WssClient::Connection> /*connection*/,
+                       int status, const string& /*reason*/) {
     cout << "Connection closed with status code " << status << endl;
     connection = NULL;
     isClosed = true;
   };
 
-  // See http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html, Error Codes for error code meanings
-  client.on_error = [](shared_ptr<WssClient::Connection> /*connection*/, const SimpleWeb::error_code &ec) {
+  // See
+  // http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html,
+  // Error Codes for error code meanings
+  client.on_error = [](shared_ptr<WssClient::Connection> /*connection*/,
+                       const SimpleWeb::error_code& ec) {
     cout << "Error: " << ec << ", message: " << ec.message() << endl;
     isClosed = true;
   };
 
-client.start();
+  client.start();
 }
 
 // Main
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
+  if (argc == 5) {
+    strcpy(PORT, argv[1]);
+    strcpy(TOKEN, argv[2]);
+    AVTHREADSLEEP = atoi(argv[3]);
+    DTCTHREADSLEEP = atoi(argv[4]);
+  } else {
+    cerr << "Usage ./elm327_visfeeder <ELM327-PORT>  <JWT TOKEN> "
+            "<AVTHREADDELAY> <DTCTHREADDELAY>"
+         << endl;
+    return -1;
+  }
 
-        if(argc == 5) {
-           strcpy(PORT , argv[1]);
-           strcpy(TOKEN , argv[2]);
-           AVTHREADSLEEP = atoi(argv[3]);
-           DTCTHREADSLEEP = atoi(argv[4]);
-        } else {
-           cerr<<"Usage ./elm327_visfeeder <ELM327-PORT>  <JWT TOKEN> <AVTHREADDELAY> <DTCTHREADDELAY>"<<endl;
-           return -1; 
-        }
+  pthread_t startWSClient_thread;
 
-        pthread_t startWSClient_thread;
+  /* create the web socket client thread. */
+  if (pthread_create(&startWSClient_thread, NULL, &startWSClient, NULL)) {
+    cout << "Error creating websocket client run thread" << endl;
+    return 1;
+  }
 
-        /* create the web socket client thread. */
-        if(pthread_create(&startWSClient_thread, NULL, &startWSClient, NULL )) {
-           cout << "Error creating websocket client run thread"<<endl;
-           return 1;
-        }
-
-       while (!isClosed) { usleep (1000000); }; // Loop until websocket connection exists.
-       cout << "Exiting ELM327-datafeeder main thread because of possible error" << endl; 
-       return 1;
-
+  while (!isClosed) {
+    usleep(1000000);
+  };  // Loop until websocket connection exists.
+  cout << "Exiting ELM327-datafeeder main thread because of possible error"
+       << endl;
+  return 1;
 }

--- a/elm327-visdatafeeder/src/obd.cpp
+++ b/elm327-visdatafeeder/src/obd.cpp
@@ -11,28 +11,31 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include"obd.hpp"
-#include <iostream>
-#include <fcntl.h>
-#include <termios.h>
-#include <unistd.h>
+#include "obd.hpp"
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <termios.h>
 #include <unistd.h>
+#include <unistd.h>
+#include <iostream>
 
 using namespace std;
 
 // OBDII serial port setting.
 
-// To change the baud rate on the kuksa-OBD-Dongle use the below commands and also modify the value below.
+// To change the baud rate on the kuksa-OBD-Dongle use the below commands and
+// also modify the value below.
 // The serial device is /dev/ttyAMA0
-// Open using screen using the current baud rate -> screen /dev/ttyAMA0 <PRESENT BAUD RATE>
+// Open using screen using the current baud rate -> screen /dev/ttyAMA0 <PRESENT
+// BAUD RATE>
 // You should see ">" prompt
-// now type STSBR <NEW BAUD RATE> press enter and you should see OK on the screen.
+// now type STSBR <NEW BAUD RATE> press enter and you should see OK on the
+// screen.
 // now type STWBR press enter and you should get an "OK" on the screen
 // Close the screen window.
-#define BAUD_RATE B2000000 //2Mbps
+#define BAUD_RATE B2000000  // 2Mbps
 extern char PORT[128];
 
 // OBDII connection handle.
@@ -42,229 +45,223 @@ int connectionHandle = -1;
 pthread_mutex_t obdMutex;
 
 // filter out unwanted characters from raw data from the vehicle.
-void filter( char * str , int size) {
-   int index = 0;
-   for(int i=0; i< size; i++) {
-        if(str[i] == '\r' || str[i] == '\n')
-           continue;
-        else if (str[i] == ':') {
-           //TODO: this will work only for 1-9 blocks, but this suffices the present requirement. This may cause a problem with Reading DTC, for
-           // sensor values should not matter. 
-           index = index - 2;
-           continue;
-        } else if (str[i] == '>') {
-           str[index++] = '\0';
-           return;
-        }
-        str[index++] = str[i];
-   }
+void filter(char* str, int size) {
+  int index = 0;
+  for (int i = 0; i < size; i++) {
+    if (str[i] == '\r' || str[i] == '\n')
+      continue;
+    else if (str[i] == ':') {
+      // TODO: this will work only for 1-9 blocks, but this suffices the present
+      // requirement. This may cause a problem with Reading DTC, for
+      // sensor values should not matter.
+      index = index - 2;
+      continue;
+    } else if (str[i] == '>') {
+      str[index++] = '\0';
+      return;
+    }
+    str[index++] = str[i];
+  }
 }
 
 // Reset ELM327.
-void resetELM() {   
-   string reset =  "ATZ\r";
+void resetELM() {
+  string reset = "ATZ\r";
 
-   int res = write(connectionHandle,(char*)reset.c_str(), 4);
-    
-   fsync(connectionHandle);
-   usleep(50000);
-   
-   char read_buffer[64];
-   int bytes_read = read(connectionHandle, &read_buffer, 64);
+  int res = write(connectionHandle, (char*)reset.c_str(), 4);
 
-   filter(read_buffer, bytes_read);
-   cout << "RESET OBDII respone = " << string(read_buffer) << endl;
+  fsync(connectionHandle);
+  usleep(50000);
+
+  char read_buffer[64];
+  int bytes_read = read(connectionHandle, &read_buffer, 64);
+
+  filter(read_buffer, bytes_read);
+  cout << "RESET OBDII respone = " << string(read_buffer) << endl;
 }
 
 // Set protocol on ELM327.
 void setProtocol(int protocol) {
-   // TODO : Needs to be extended for other protocols.
-   // set protocol to automatic
-   string setProt = "ATSP0\r";
-   write(connectionHandle,(char*)setProt.c_str(), 6);
-   fsync(connectionHandle);
-   usleep(50000);
-   char read_buffer[64];
-   int bytes_read = read(connectionHandle, &read_buffer, 64);
-   filter(read_buffer, bytes_read);
+  // TODO : Needs to be extended for other protocols.
+  // set protocol to automatic
+  string setProt = "ATSP0\r";
+  write(connectionHandle, (char*)setProt.c_str(), 6);
+  fsync(connectionHandle);
+  usleep(50000);
+  char read_buffer[64];
+  int bytes_read = read(connectionHandle, &read_buffer, 64);
+  filter(read_buffer, bytes_read);
 #ifdef DEBUG
-   cout << "response for Setprotocol to automatic is " << string(read_buffer) << endl;
+  cout << "response for Setprotocol to automatic is " << string(read_buffer)
+       << endl;
 #endif
 }
-
 
 // Connect to OBD II
-bool connectOBD(int timeout)
-{
+bool connectOBD(int timeout) {
+  if (connectionHandle != -1) {
+    cout << "seems like a connection is already active !!" << endl;
+    return false;
+  }
 
-   if( connectionHandle != -1 ) {
-       cout<<"seems like a connection is already active !!"<<endl;
-       return false;
-   }
+  struct termios SerialPortSettings;
+  memset(&SerialPortSettings, 0, sizeof(SerialPortSettings));
 
-   struct termios SerialPortSettings;
-   memset(&SerialPortSettings, 0, sizeof(SerialPortSettings));
-   
-   // get the comm parameters.
-   tcgetattr(connectionHandle, &SerialPortSettings);
-   
-    SerialPortSettings.c_iflag &= ~(INLCR | ICRNL);
-    SerialPortSettings.c_iflag |= IGNPAR | IGNBRK;
-    SerialPortSettings.c_oflag &= ~(OPOST | ONLCR | OCRNL);
-    SerialPortSettings.c_cflag &= ~(PARENB | PARODD | CSTOPB | CSIZE | CRTSCTS); /* do not enable flow control, disable parity checking */
-    SerialPortSettings.c_cflag |= CLOCAL | CREAD | CS8;
-    SerialPortSettings.c_lflag &= ~(ICANON | ISIG | ECHO);
+  // get the comm parameters.
+  tcgetattr(connectionHandle, &SerialPortSettings);
 
-   SerialPortSettings.c_cc[VMIN]  = 10; /* Read 30 characters */
-   SerialPortSettings.c_cc[VTIME] = 10; // wait for val/10 seconds between each byte received.
+  SerialPortSettings.c_iflag &= ~(INLCR | ICRNL);
+  SerialPortSettings.c_iflag |= IGNPAR | IGNBRK;
+  SerialPortSettings.c_oflag &= ~(OPOST | ONLCR | OCRNL);
+  SerialPortSettings.c_cflag &=
+      ~(PARENB | PARODD | CSTOPB | CSIZE |
+        CRTSCTS); /* do not enable flow control, disable parity checking */
+  SerialPortSettings.c_cflag |= CLOCAL | CREAD | CS8;
+  SerialPortSettings.c_lflag &= ~(ICANON | ISIG | ECHO);
 
-   connectionHandle = open(PORT, O_RDWR | O_NOCTTY | O_NDELAY);
-   // set the comm parameters for ELM 327 with Bluetooth.
-   cfsetispeed(&SerialPortSettings,BAUD_RATE);
-   cfsetospeed(&SerialPortSettings,BAUD_RATE);
+  SerialPortSettings.c_cc[VMIN] = 10; /* Read 30 characters */
+  SerialPortSettings.c_cc[VTIME] =
+      10;  // wait for val/10 seconds between each byte received.
 
-   if(connectionHandle == -1) {
-      cout<< " Error while opening the serial port connection to ELM 327" << endl;
-      return false;
-   }
-   else {
-      cout<< " Connection to the port sucessful with val "<< connectionHandle << endl;
-   }
- 
-   tcsetattr(connectionHandle,TCSANOW,&SerialPortSettings);
+  connectionHandle = open(PORT, O_RDWR | O_NOCTTY | O_NDELAY);
+  // set the comm parameters for ELM 327 with Bluetooth.
+  cfsetispeed(&SerialPortSettings, BAUD_RATE);
+  cfsetospeed(&SerialPortSettings, BAUD_RATE);
 
-   // Apply ELM 327 settings.
-   fcntl(connectionHandle, F_SETFL, 0);
+  if (connectionHandle == -1) {
+    cout << " Error while opening the serial port connection to ELM 327"
+         << endl;
+    return false;
+  } else {
+    cout << " Connection to the port sucessful with val " << connectionHandle
+         << endl;
+  }
 
-   pthread_mutex_lock (&obdMutex);  
-   resetELM();   
-   //usleep(200000);
-   //setProtocol(0);
-   pthread_mutex_unlock (&obdMutex);
-   
-   return true;
+  tcsetattr(connectionHandle, TCSANOW, &SerialPortSettings);
+
+  // Apply ELM 327 settings.
+  fcntl(connectionHandle, F_SETFL, 0);
+
+  pthread_mutex_lock(&obdMutex);
+  resetELM();
+  // usleep(200000);
+  // setProtocol(0);
+  pthread_mutex_unlock(&obdMutex);
+
+  return true;
 }
 
-
 // Method to read OBDII Mode 1 values.
-string readMode1Data(string command)
-{
-   pthread_mutex_lock (&obdMutex);  
-   char write_buf[6];
-   memcpy(write_buf , command.c_str(), 6);
+string readMode1Data(string command) {
+  pthread_mutex_lock(&obdMutex);
+  char write_buf[6];
+  memcpy(write_buf, command.c_str(), 6);
 
-   int res = write(connectionHandle,write_buf, 6);
-   fsync(connectionHandle);
-   char read_buffer[64] = {0};
-   char character;
-   int bytes_read = 0;
-   while((read(connectionHandle, &character, 1)) && character != '>') {
-       read_buffer[bytes_read++] = character;
-   }
-   pthread_mutex_unlock (&obdMutex);  
+  int res = write(connectionHandle, write_buf, 6);
+  fsync(connectionHandle);
+  char read_buffer[64] = {0};
+  char character;
+  int bytes_read = 0;
+  while ((read(connectionHandle, &character, 1)) && character != '>') {
+    read_buffer[bytes_read++] = character;
+  }
+  pthread_mutex_unlock(&obdMutex);
 
-   filter(read_buffer, bytes_read);
+  filter(read_buffer, bytes_read);
 
-   string response (read_buffer);
+  string response(read_buffer);
 #ifdef DEBUG
-   cout << "Sensor Data as string from vehicle ="<< endl << response << endl;
+  cout << "Sensor Data as string from vehicle =" << endl << response << endl;
 #endif
-   
-   return response;
+
+  return response;
 }
 
 // Method to read OBDII Mode 3 values.
 string readMode3Data() {
-   pthread_mutex_lock (&obdMutex);  
-   char cmdBuf[3] = {'0','3','\r'};
+  pthread_mutex_lock(&obdMutex);
+  char cmdBuf[3] = {'0', '3', '\r'};
 
-   int res = write(connectionHandle,cmdBuf, 3);
-   fsync(connectionHandle);
-   char read_buffer[128] = {0};
-   char character;
-   int bytes_read = 0;
-   while((read(connectionHandle, &character, 1)) && character != '>') {
-       read_buffer[bytes_read++] = character;
-   }
+  int res = write(connectionHandle, cmdBuf, 3);
+  fsync(connectionHandle);
+  char read_buffer[128] = {0};
+  char character;
+  int bytes_read = 0;
+  while ((read(connectionHandle, &character, 1)) && character != '>') {
+    read_buffer[bytes_read++] = character;
+  }
 #ifdef DEBUG
-   cout << "Total bytes read =" << bytes_read <<endl;
+  cout << "Total bytes read =" << bytes_read << endl;
 #endif
-   pthread_mutex_unlock (&obdMutex);  
-   filter(read_buffer, bytes_read);
-   string response (read_buffer);
+  pthread_mutex_unlock(&obdMutex);
+  filter(read_buffer, bytes_read);
+  string response(read_buffer);
 
 #ifdef DEBUG
-   cout << "Error Data as string from vehicle ="<< endl << response << endl;
+  cout << "Error Data as string from vehicle =" << endl << response << endl;
 #endif
-   return response;  
+  return response;
 }
 
-// Method to write Mode 8 vallues to the (CAN) BUS. 
+// Method to write Mode 8 vallues to the (CAN) BUS.
 string writeMode8Data(string command) {
-   pthread_mutex_lock (&obdMutex);  
-   char write_buf[16];
-   memcpy(write_buf , command.c_str(), 16);
+  pthread_mutex_lock(&obdMutex);
+  char write_buf[16];
+  memcpy(write_buf, command.c_str(), 16);
 
-   int res = write(connectionHandle,write_buf, 16);
-   fsync(connectionHandle);
+  int res = write(connectionHandle, write_buf, 16);
+  fsync(connectionHandle);
 
-  
-   
-   char read_buffer[64] = {0};
-   char character;
-   int bytes_read = 0;
-   while((read(connectionHandle, &character, 1)) && character != '>') {
-       read_buffer[bytes_read++] = character;
-   }
+  char read_buffer[64] = {0};
+  char character;
+  int bytes_read = 0;
+  while ((read(connectionHandle, &character, 1)) && character != '>') {
+    read_buffer[bytes_read++] = character;
+  }
 
-   fsync(connectionHandle);
-   tcflush(connectionHandle,TCIOFLUSH);
-   pthread_mutex_unlock (&obdMutex);  
+  fsync(connectionHandle);
+  tcflush(connectionHandle, TCIOFLUSH);
+  pthread_mutex_unlock(&obdMutex);
 
-   filter(read_buffer, bytes_read);
+  filter(read_buffer, bytes_read);
 
-   string response (read_buffer);
+  string response(read_buffer);
 #ifdef DEBUG
-   cout << "Response for mode 8 as string from vehicle ="<< endl << response << endl;
+  cout << "Response for mode 8 as string from vehicle =" << endl
+       << response << endl;
 #endif
-   
-   return response;
 
+  return response;
 }
 
 // Close OBDII connection
-void closeConnection() {
-    close(connectionHandle);
-}
+void closeConnection() { close(connectionHandle); }
 
 //  Test method.
 int testCommands(string command, char* response) {
-     
-     command = command + '\r';
-     int length = command.length();
-     int res = write(connectionHandle,(char*)command.c_str(), length);
-     fsync(connectionHandle);
+  command = command + '\r';
+  int length = command.length();
+  int res = write(connectionHandle, (char*)command.c_str(), length);
+  fsync(connectionHandle);
 
-     usleep(500000);
-
-#ifdef DEBUG
-     if( res != length) {
-        cout<< "not all request bytes written to the buffer! bytes written = " << res << endl;
-     }
-#endif
-    
-     char character;
-     int bytes_read = 0;
-     while((read(connectionHandle, &character, 1)) && character != '>') {
-       response[bytes_read++] = character;
-     }
+  usleep(500000);
 
 #ifdef DEBUG
-     cout << "Total bytes read as response = " << bytes_read << endl;
+  if (res != length) {
+    cout << "not all request bytes written to the buffer! bytes written = "
+         << res << endl;
+  }
 #endif
-     filter(response, bytes_read);
-     return bytes_read;
+
+  char character;
+  int bytes_read = 0;
+  while ((read(connectionHandle, &character, 1)) && character != '>') {
+    response[bytes_read++] = character;
+  }
+
+#ifdef DEBUG
+  cout << "Total bytes read as response = " << bytes_read << endl;
+#endif
+  filter(response, bytes_read);
+  return bytes_read;
 }
-
-
-

--- a/elm327-visdatafeeder/src/test_main.cpp
+++ b/elm327-visdatafeeder/src/test_main.cpp
@@ -13,8 +13,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <string>
 #include <iostream>
+#include <string>
 #include "obd.hpp"
 
 char* PORT;
@@ -24,27 +24,24 @@ int DTCTHREADSLEEP = 100000;
 
 using namespace std;
 
+int main(int argc, char* argv[]) {
+  string command;
+  char response[256] = {'\0'};
+  ;
+  if (argc == 2) {
+    PORT = argv[1];
+    cout << " ELM 327 app started with PORT= " << PORT << endl;
+  } else {
+    cerr << "Usage ./elm327 <PORT>" << endl;
+  }
 
-int main(int argc, char* argv[])
-{
-     string command;
-     char response[256] = {'\0'};;
-        if(argc == 2) {
-          PORT = argv[1];
-          cout <<" ELM 327 app started with PORT= " << PORT <<endl; 
-        } else {
-          cerr <<"Usage ./elm327 <PORT>" <<endl;
-        }
+  while (true) {
+    cout << "ENTER COMMAND:" << endl;
+    getline(cin, command);
+    testCommands(command, response);
+    cout << "RESPONSE:" << endl << response << endl;
+  }
 
-      
-       while(true) {
-         cout<<"ENTER COMMAND:" << endl;
-         getline (cin, command);
-         testCommands(command, response);
-         cout<<"RESPONSE:"<< endl<< response <<endl;
-       }
-       
-      getchar();
-      return 0;
+  getchar();
+  return 0;
 }
-

--- a/elm327-visdatafeeder/src/vssMapper.cpp
+++ b/elm327-visdatafeeder/src/vssMapper.cpp
@@ -12,29 +12,28 @@
  * *****************************************************************************
  */
 #include "vssMapper.hpp"
-#include "obd.hpp"
 #include <string.h>
 #include <iostream>
 #include <json.hpp>
-
+#include "obd.hpp"
 
 using namespace std;
 using namespace jsoncons;
 
-typedef unsigned char UInt8 ; 
-typedef unsigned short int UInt16 ;
-typedef unsigned long int UInt32 ;
-typedef signed char Int8 ;
-typedef short int Int16 ;
-typedef long int Int32 ;
-typedef float Float ;
-typedef double Double ;
-typedef bool Boolean ;
+typedef unsigned char UInt8;
+typedef unsigned short int UInt16;
+typedef unsigned long int UInt32;
+typedef signed char Int8;
+typedef short int Int16;
+typedef long int Int32;
+typedef float Float;
+typedef double Double;
+typedef bool Boolean;
 
 // Utility tokenizer.
-int tokenizeResponse(char** tokens , string response) {
+int tokenizeResponse(char** tokens, string response) {
   char* cString = strdup(response.c_str());
-  char *tok = strtok(cString, " ");
+  char* tok = strtok(cString, " ");
   int i = 0;
   while (tok != NULL) {
     tokens[i++] = strdup(tok);
@@ -46,161 +45,158 @@ int tokenizeResponse(char** tokens , string response) {
 
 // Utility method to create W3C-VIS SET request
 json setRequest(string path) {
-
   json req;
   req["requestId"] = rand() % 99999;
-  req["action"]= "set";
+  req["action"] = "set";
   req["path"] = string(path);
   return req;
 }
 
 // Reads RPM from the vehicle and packs the response in w3c-VIS SET request.
 string setRPM() {
-
   string readBuf = readMode1Data("01 0C\r");
   int pos = readBuf.find("41 0C", 0);
-  
-  if( pos == -1) {
-      cout << "Response "<< readBuf <<" not valid for RPM" << endl;
-      return "Error";
+
+  if (pos == -1) {
+    cout << "Response " << readBuf << " not valid for RPM" << endl;
+    return "Error";
   }
 
-  string response = readBuf.substr (pos, 12);
+  string response = readBuf.substr(pos, 12);
 
   if (response.empty()) {
-      cout << "RPM Data is NULL form vehicle!" <<endl;
-      return "Error";
+    cout << "RPM Data is NULL form vehicle!" << endl;
+    return "Error";
   }
-  
+
   char* tokens[4];
-  tokenizeResponse(tokens , response);
+  tokenizeResponse(tokens, response);
 
-  if(string(tokens[1]) != "0C"){
-     cout<< "PID not matching for RPM!" <<endl;
-     return "Error";
+  if (string(tokens[1]) != "0C") {
+    cout << "PID not matching for RPM!" << endl;
+    return "Error";
   }
 
-  int A = stoi (string(tokens[2]),nullptr,16);
-  int B = stoi (string(tokens[3]),nullptr,16);
-  
+  int A = stoi(string(tokens[2]), nullptr, 16);
+  int B = stoi(string(tokens[3]), nullptr, 16);
+
   UInt16 value = (A * 256 + B) / 4;
 #ifdef DEBUG
-  cout << "RPMread from the vehicle = "<< value << endl;
+  cout << "RPMread from the vehicle = " << value << endl;
 #endif
 
-  json req = setRequest("Signal.OBD.RPM"); 
+  json req = setRequest("Signal.OBD.RPM");
   req["value"] = value;
-  stringstream ss; 
+  stringstream ss;
   ss << pretty_print(req);
   string resp = ss.str();
   return resp;
 }
 
-// Reads Engine speed from the vehicle and packs the response in w3c-VIS SET request.
+// Reads Engine speed from the vehicle and packs the response in w3c-VIS SET
+// request.
 string setVehicleSpeed() {
-
   string readBuf = readMode1Data("01 0D\r");
   int pos = readBuf.find("41 0D", 0);
 
-  if( pos == -1) {
-      cout << "Response "<< readBuf <<" not valid for Vehicle speed" << endl;
-      return "Error";
+  if (pos == -1) {
+    cout << "Response " << readBuf << " not valid for Vehicle speed" << endl;
+    return "Error";
   }
 
-  string response = readBuf.substr (pos, 9);
+  string response = readBuf.substr(pos, 9);
 
   if (response.empty()) {
-      cout << "Vehicle Speed Data is NULL form vehicle!" <<endl;
-      return "Error";
+    cout << "Vehicle Speed Data is NULL form vehicle!" << endl;
+    return "Error";
   }
   char* tokens[3];
-  tokenizeResponse(tokens , response);
+  tokenizeResponse(tokens, response);
 
-  if(string(tokens[1]) != "0D"){
-     cout<< "PID not matching for vehicle speed!" <<endl;
-     return "Error";
+  if (string(tokens[1]) != "0D") {
+    cout << "PID not matching for vehicle speed!" << endl;
+    return "Error";
   }
 
-  int A = stoi (string(tokens[2]),nullptr,16);
- 
-  Int32 value = A ;
+  int A = stoi(string(tokens[2]), nullptr, 16);
+
+  Int32 value = A;
 #ifdef DEBUG
-  cout << "Vehicle speed read from the vehicle = "<< value << endl;
+  cout << "Vehicle speed read from the vehicle = " << value << endl;
 #endif
-  json req = setRequest("Signal.OBD.Speed"); 
+  json req = setRequest("Signal.OBD.Speed");
   req["value"] = value;
-  stringstream ss; 
+  stringstream ss;
   ss << pretty_print(req);
   string resp = ss.str();
-  cout << resp << endl; 
+  cout << resp << endl;
   return resp;
 }
 
-// Reads Fuel status from the vehicle and packs the response in w3c-VIS SET request.
+// Reads Fuel status from the vehicle and packs the response in w3c-VIS SET
+// request.
 string setFuelLevel() {
-
   string readBuf = readMode1Data("01 2F\r");
   int pos = readBuf.find("41 2F", 0);
 
-  if( pos == -1) {
-      cout << "Response not valid for Fuel level" << endl;
-      return "Error";
+  if (pos == -1) {
+    cout << "Response not valid for Fuel level" << endl;
+    return "Error";
   }
 
-  string response = readBuf.substr (pos, 9);
+  string response = readBuf.substr(pos, 9);
 
   if (response.empty()) {
-      cout<<"Fuel level Vehicle Speed Data is NULL form vehicle!" <<endl;
-      return "Error";
+    cout << "Fuel level Vehicle Speed Data is NULL form vehicle!" << endl;
+    return "Error";
   }
   char* tokens[3];
-  tokenizeResponse(tokens , response);
+  tokenizeResponse(tokens, response);
 
-  if(string(tokens[1]) != "2F"){
-     cout<< "PID not matching for Fuel level!" <<endl;
-     return "Error";
+  if (string(tokens[1]) != "2F") {
+    cout << "PID not matching for Fuel level!" << endl;
+    return "Error";
   }
 
-  int A = stoi (string(tokens[2]),nullptr,16);
- 
-  Int32 value = A ;
+  int A = stoi(string(tokens[2]), nullptr, 16);
+
+  Int32 value = A;
   value = (value * 100) / 255;
-#ifdef DEBUG 
-  cout << "Fuel level read from the vehicle = "<< value << endl;
+#ifdef DEBUG
+  cout << "Fuel level read from the vehicle = " << value << endl;
 #endif
-  json req = setRequest("Signal.OBD.FuelLevel"); 
+  json req = setRequest("Signal.OBD.FuelLevel");
   req["value"] = value;
-  stringstream ss; 
+  stringstream ss;
   ss << pretty_print(req);
   string resp = ss.str();
-  cout << resp << endl; 
+  cout << resp << endl;
   return resp;
 }
 
 // Utility method to pack DTC data in W3C-VIS SET format.
-string createDTCJson( string dtcCode ) {
-
+string createDTCJson(string dtcCode) {
   json req;
-  if( dtcCode == "0104") {
-     req = setRequest("Signal.OBD.DTC1");
-     req["value"] = true; 
-  } else if( dtcCode == "0105"){
-     req = setRequest("Signal.OBD.DTC2");
-     req["value"] = true; 
-  } else if( dtcCode == "0106"){
-     req = setRequest("Signal.OBD.DTC3");
-     req["value"] = true; 
-  } else if( dtcCode == "0107"){
-     req = setRequest("Signal.OBD.DTC4");
-     req["value"] = true; 
-  } else if( dtcCode == "0108"){
-     req = setRequest("Signal.OBD.DTC5");
-     req["value"] = true; 
-  } else if( dtcCode == "0109"){
-     req = setRequest("Signal.OBD.DTC6");
-     req["value"] = true; 
+  if (dtcCode == "0104") {
+    req = setRequest("Signal.OBD.DTC1");
+    req["value"] = true;
+  } else if (dtcCode == "0105") {
+    req = setRequest("Signal.OBD.DTC2");
+    req["value"] = true;
+  } else if (dtcCode == "0106") {
+    req = setRequest("Signal.OBD.DTC3");
+    req["value"] = true;
+  } else if (dtcCode == "0107") {
+    req = setRequest("Signal.OBD.DTC4");
+    req["value"] = true;
+  } else if (dtcCode == "0108") {
+    req = setRequest("Signal.OBD.DTC5");
+    req["value"] = true;
+  } else if (dtcCode == "0109") {
+    req = setRequest("Signal.OBD.DTC6");
+    req["value"] = true;
   }
-  stringstream ss; 
+  stringstream ss;
   ss << pretty_print(req);
   string resp = ss.str();
 #ifdef DEBUG
@@ -210,77 +206,76 @@ string createDTCJson( string dtcCode ) {
 }
 
 // Reads DTCs from the vehicle and packs the response in w3c-VIS SET request.
-// Updates 6 DTCs in VSS tree (0104, 0105, 0106, 0107, 0108 and 0109). These are some dummy values. 
+// Updates 6 DTCs in VSS tree (0104, 0105, 0106, 0107, 0108 and 0109). These are
+// some dummy values.
 list<string> readErrors() {
-   
   list<string> errorList;
   string readBuf = readMode3Data();
   int pos = readBuf.find("43", 0);
 
-  if( pos == -1) {
-      cout << "Response not valid for Error reading" << endl;
-      return errorList;
+  if (pos == -1) {
+    cout << "Response not valid for Error reading" << endl;
+    return errorList;
   }
 
-  string response = readBuf.substr (pos);
-
+  string response = readBuf.substr(pos);
 
   cout << response << endl;
   if (response.empty()) {
-      cout << "DTC Data is NULL from vehicle!" <<endl;
-      return errorList;
+    cout << "DTC Data is NULL from vehicle!" << endl;
+    return errorList;
   }
   char* tokens[64];
-  int tknos = tokenizeResponse(tokens , response);
+  int tknos = tokenizeResponse(tokens, response);
 
-  int dtcNos = stoi (string(tokens[1]),nullptr,10);
+  int dtcNos = stoi(string(tokens[1]), nullptr, 10);
 #ifdef DEBUG
-  cout <<"" << dtcNos << " Errors found" << endl;
+  cout << "" << dtcNos << " Errors found" << endl;
 #endif
 
-  if ( dtcNos > 0) {
-       for(int i=0 ; i < dtcNos*2 ; i++) {
-          stringstream ss;
-          ss << tokens[2 + i];
-          i++;
-          ss << tokens[2 + i];
+  if (dtcNos > 0) {
+    for (int i = 0; i < dtcNos * 2; i++) {
+      stringstream ss;
+      ss << tokens[2 + i];
+      i++;
+      ss << tokens[2 + i];
 
-          string dtcCode = ss.str();
-          errorList.push_back(createDTCJson(dtcCode));
-       }
-   } else if ( dtcNos == 0) {
-      // clear all errors.
-      json req;
-      req = setRequest("Signal.OBD.*");
-      json array = json::array();
-      json dtc1;
-      dtc1["DTC1"] = false;
-      array.push_back(dtc1);
-      json dtc2;
-      dtc2["DTC2"] = false;
-      array.push_back(dtc2);
-      json dtc3;
-      dtc3["DTC3"] = false;
-      array.push_back(dtc3);
-      json dtc4;
-      dtc4["DTC4"] = false;
-      array.push_back(dtc4);
-      json dtc5;
-      dtc5["DTC5"] = false;
-      array.push_back(dtc5);
-      json dtc6;
-      dtc6["DTC6"] = false;
-      array.push_back(dtc6);
-      
-      req["value"] = array;
-      stringstream ss; 
-      ss << pretty_print(req);
-      string resp = ss.str();
+      string dtcCode = ss.str();
+      errorList.push_back(createDTCJson(dtcCode));
+    }
+  } else if (dtcNos == 0) {
+    // clear all errors.
+    json req;
+    req = setRequest("Signal.OBD.*");
+    json array = json::array();
+    json dtc1;
+    dtc1["DTC1"] = false;
+    array.push_back(dtc1);
+    json dtc2;
+    dtc2["DTC2"] = false;
+    array.push_back(dtc2);
+    json dtc3;
+    dtc3["DTC3"] = false;
+    array.push_back(dtc3);
+    json dtc4;
+    dtc4["DTC4"] = false;
+    array.push_back(dtc4);
+    json dtc5;
+    dtc5["DTC5"] = false;
+    array.push_back(dtc5);
+    json dtc6;
+    dtc6["DTC6"] = false;
+    array.push_back(dtc6);
+
+    req["value"] = array;
+    stringstream ss;
+    ss << pretty_print(req);
+    string resp = ss.str();
 #ifdef DEBUG
-      cout << resp << endl;
+    cout << resp << endl;
 #endif
-      errorList.push_back(resp);
-   }
+    errorList.push_back(resp);
+  }
 
   return errorList;
 }

--- a/w3c-visserver-api/.clang-format
+++ b/w3c-visserver-api/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/w3c-visserver-api/include/accesschecker.hpp
+++ b/w3c-visserver-api/include/accesschecker.hpp
@@ -14,28 +14,24 @@
 #ifndef __ACCESSCHECKER_H__
 #define __ACCESSCHECKER_H__
 
-#include <string>
 #include <jsoncons/json.hpp>
-#include "wschannel.hpp"
+#include <string>
 #include "authenticator.hpp"
+#include "wschannel.hpp"
 
 using namespace std;
 using namespace jsoncons;
 using jsoncons::json;
 
 class accesschecker {
+ private:
+  class authenticator* tokenValidator;
 
-  private:
-    class  authenticator* tokenValidator;
-
-  public:  
-     accesschecker(class  authenticator* vdator);
-     bool checkReadAccess (class wschannel& channel, string path);
-     bool checkWriteAccess (class wschannel& channel, string path);
-     bool checkPathWriteAccess (class wschannel& channel, json paths);  
-
+ public:
+  accesschecker(class authenticator* vdator);
+  bool checkReadAccess(class wschannel& channel, string path);
+  bool checkWriteAccess(class wschannel& channel, string path);
+  bool checkPathWriteAccess(class wschannel& channel, json paths);
 };
-
-
 
 #endif

--- a/w3c-visserver-api/include/authenticator.hpp
+++ b/w3c-visserver-api/include/authenticator.hpp
@@ -16,24 +16,23 @@
 
 #include <jwt-cpp/jwt.h>
 #include <jsoncons/json.hpp>
-#include "wschannel.hpp"
 #include "vssdatabase.hpp"
+#include "wschannel.hpp"
 
 using namespace std;
 using namespace jsoncons;
 using jsoncons::json;
 
 class authenticator {
+ private:
+  string key = "secret";
+  string algorithm = "HS256";
 
-private:
-    string key = "secret";
-    string algorithm = "HS256";
-
-public:
-   authenticator(string secretkey, string algorithm);
-   int validate (wschannel &channel, class vssdatabase* database, string authToken);
-   bool isStillValid (wschannel &channel);
-   json resolvePermissions(wschannel &channel, class vssdatabase* database);
-
+ public:
+  authenticator(string secretkey, string algorithm);
+  int validate(wschannel &channel, class vssdatabase *database,
+               string authToken);
+  bool isStillValid(wschannel &channel);
+  json resolvePermissions(wschannel &channel, class vssdatabase *database);
 };
 #endif

--- a/w3c-visserver-api/include/exception.hpp
+++ b/w3c-visserver-api/include/exception.hpp
@@ -20,76 +20,49 @@
 using namespace std;
 
 // No path on Tree exception
-class noPathFoundonTree: public exception
-{
-  private:
-    string message; 
+class noPathFoundonTree : public exception {
+ private:
+  string message;
 
-  public:
-    
-    noPathFoundonTree(string path) {
-        message = "Path " + path + " not found on the VSS Tree";
-    }
-
-  virtual const char* what() const throw()
-  {
-    return message.c_str();
+ public:
+  noPathFoundonTree(string path) {
+    message = "Path " + path + " not found on the VSS Tree";
   }
-} ;
+
+  virtual const char* what() const throw() { return message.c_str(); }
+};
 
 // Generic exception
-class genException: public exception
-{
-  private:
-    string message;
+class genException : public exception {
+ private:
+  string message;
 
-  public:
-    
-    genException(string msg) {
-       message = msg;
-    }
+ public:
+  genException(string msg) { message = msg; }
 
-  virtual const char* what() const throw()
-  {
-    return message.c_str();
-  }
-} ;
+  virtual const char* what() const throw() { return message.c_str(); }
+};
 
 // not permitted- no permission
-class noPermissionException: public exception
-{
-  private:
-    string message;
+class noPermissionException : public exception {
+ private:
+  string message;
 
-  public:
-    
-    noPermissionException(string msg) {
-       message = msg;
-    }
+ public:
+  noPermissionException(string msg) { message = msg; }
 
-  virtual const char* what() const throw()
-  {
-    return message.c_str();
-  }
-} ;
+  virtual const char* what() const throw() { return message.c_str(); }
+};
 
 // value out of bound exception
-class outOfBoundException: public exception
-{
-  private:
-    string message;
+class outOfBoundException : public exception {
+ private:
+  string message;
 
-  public:
-    
-    outOfBoundException(string msg) {
-       message = msg;
-    }
+ public:
+  outOfBoundException(string msg) { message = msg; }
 
-  virtual const char* what() const throw()
-  {
-    return message.c_str();
-  }
-} ;
+  virtual const char* what() const throw() { return message.c_str(); }
+};
 
 #endif
-

--- a/w3c-visserver-api/include/signing.hpp
+++ b/w3c-visserver-api/include/signing.hpp
@@ -16,29 +16,28 @@
 
 #include <jwt-cpp/base.h>
 #include <jwt-cpp/jwt.h>
-#include <jsoncons/json.hpp>
 #include <fstream>
 #include <iostream>
+#include <jsoncons/json.hpp>
 
 using namespace std;
 using namespace jsoncons;
 using namespace jwt;
 
 class signing {
+ private:
+  string key = "";
+  string pubkey = "";
+  string algorithm = "RS256";
 
-private:
-    string key = "";
-    string pubkey = "";
-    string algorithm = "RS256";
-
-public:
-   signing();
-   string getKey (string fileName);
-   string getPublicKey (string fileName);
-   string sign(json data);
-   string sign(string data);
+ public:
+  signing();
+  string getKey(string fileName);
+  string getPublicKey(string fileName);
+  string sign(json data);
+  string sign(string data);
 #ifdef UNIT_TEST
-   string decode(string signedData);
+  string decode(string signedData);
 #endif
 };
 

--- a/w3c-visserver-api/include/subscriptionhandler.hpp
+++ b/w3c-visserver-api/include/subscriptionhandler.hpp
@@ -15,13 +15,12 @@
 #define __SUBSCRIPTIONHANDLER_H__
 
 #include <queue>
-#include "visconf.hpp"
-#include "wsserver.hpp"
-#include "authenticator.hpp"
-#include "vssdatabase.hpp"
 #include "accesschecker.hpp"
+#include "authenticator.hpp"
 #include "exception.hpp"
-
+#include "visconf.hpp"
+#include "vssdatabase.hpp"
+#include "wsserver.hpp"
 
 using namespace std;
 using namespace jsoncons;
@@ -29,29 +28,27 @@ using namespace jsoncons::jsonpath;
 using jsoncons::json;
 
 class subscriptionhandler {
-
  private:
-   uint32_t subscribeHandle[MAX_SIGNALS][MAX_CLIENTS];
-   class wsserver* server;
-   authenticator* validator;
-   accesschecker* checkAccess;
-   bool threadRun;
-   
-   
+  uint32_t subscribeHandle[MAX_SIGNALS][MAX_CLIENTS];
+  class wsserver* server;
+  authenticator* validator;
+  accesschecker* checkAccess;
+  bool threadRun;
 
  public:
-
-   
-   queue<pair<uint32_t, json>> buffer; 
-   subscriptionhandler(class wsserver* wserver, class authenticator* authenticate, class accesschecker* checkAccess);
-   uint32_t subscribe (class wschannel& channel, class vssdatabase* db, uint32_t channelID, string path);
-   int unsubscribe (uint32_t subscribeID);
-   int unsubscribeAll (uint32_t connectionID);
-   int update ( int signalID, json value);
-   int update ( string path, json value);
-   class wsserver* getServer();
-   int startThread();
-   int stopThread();
-   bool isThreadRunning(); 
+  queue<pair<uint32_t, json>> buffer;
+  subscriptionhandler(class wsserver* wserver,
+                      class authenticator* authenticate,
+                      class accesschecker* checkAccess);
+  uint32_t subscribe(class wschannel& channel, class vssdatabase* db,
+                     uint32_t channelID, string path);
+  int unsubscribe(uint32_t subscribeID);
+  int unsubscribeAll(uint32_t connectionID);
+  int update(int signalID, json value);
+  int update(string path, json value);
+  class wsserver* getServer();
+  int startThread();
+  int stopThread();
+  bool isThreadRunning();
 };
 #endif

--- a/w3c-visserver-api/include/vsscommandprocessor.hpp
+++ b/w3c-visserver-api/include/vsscommandprocessor.hpp
@@ -15,39 +15,40 @@
 #define __VSSCOMMANDPROCESSOR_H__
 
 #include <string>
-#include "wschannel.hpp"
-#include "vssdatabase.hpp"
-#include "subscriptionhandler.hpp"
 #include "accesschecker.hpp"
+#include "subscriptionhandler.hpp"
 #include "visconf.hpp"
+#include "vssdatabase.hpp"
+#include "wschannel.hpp"
 using namespace std;
 using namespace jsoncons;
 using namespace jsoncons::jsonpath;
 using jsoncons::json;
 
-
 class vsscommandprocessor {
-
-private:
-   class  vssdatabase* database = NULL;
-   class  subscriptionhandler* subHandler = NULL;
-   class  authenticator* tokenValidator = NULL;
-   class  accesschecker* accessValidator = NULL;
+ private:
+  class vssdatabase* database = NULL;
+  class subscriptionhandler* subHandler = NULL;
+  class authenticator* tokenValidator = NULL;
+  class accesschecker* accessValidator = NULL;
 #ifdef JSON_SIGNING_ON
-   class signing* signer = NULL;
+  class signing* signer = NULL;
 #endif
 
-   string processGet(class wschannel& channel,uint32_t request_id, string path);
-   string processSet(class wschannel& channel,uint32_t request_id, string path, json value);
-   string processSubscribe(class wschannel& channel, uint32_t request_id, string path, uint32_t connectionID);
-   string processUnsubscribe(uint32_t request_id, uint32_t subscribeID);
-   string processGetMetaData(uint32_t request_id, string path); 
-   string processAuthorize (class wschannel& channel,uint32_t request_id, string token);
+  string processGet(class wschannel& channel, uint32_t request_id, string path);
+  string processSet(class wschannel& channel, uint32_t request_id, string path,
+                    json value);
+  string processSubscribe(class wschannel& channel, uint32_t request_id,
+                          string path, uint32_t connectionID);
+  string processUnsubscribe(uint32_t request_id, uint32_t subscribeID);
+  string processGetMetaData(uint32_t request_id, string path);
+  string processAuthorize(class wschannel& channel, uint32_t request_id,
+                          string token);
 
-public:
-   vsscommandprocessor(class vssdatabase* database, class  authenticator* vdator , class subscriptionhandler* subhandler);
-   string processQuery(string req_json , class wschannel& channel);
+ public:
+  vsscommandprocessor(class vssdatabase* database, class authenticator* vdator,
+                      class subscriptionhandler* subhandler);
+  string processQuery(string req_json, class wschannel& channel);
 };
-
 
 #endif

--- a/w3c-visserver-api/include/vssdatabase.hpp
+++ b/w3c-visserver-api/include/vssdatabase.hpp
@@ -13,15 +13,15 @@
  */
 #ifndef __VSSDATABASE_HPP__
 #define __VSSDATABASE_HPP__
-#include <string>
-#include <fstream>
-#include <vector>
-#include <list>
 #include <stdint.h>
+#include <fstream>
 #include <jsoncons/json.hpp>
 #include <jsoncons_ext/jsonpath/json_query.hpp>
-#include "subscriptionhandler.hpp"
+#include <list>
+#include <string>
+#include <vector>
 #include "authenticator.hpp"
+#include "subscriptionhandler.hpp"
 #include "wschannel.hpp"
 
 #ifdef UNIT_TEST
@@ -34,11 +34,10 @@ using namespace jsoncons::jsonpath;
 using jsoncons::json;
 
 class vssdatabase {
-
-friend class subscriptionhandler;
-friend class authenticator;
+  friend class subscriptionhandler;
+  friend class authenticator;
 #ifdef UNIT_TEST
-     friend class w3cunittest;
+  friend class w3cunittest;
 #endif
 
  private:
@@ -47,16 +46,18 @@ friend class authenticator;
   json meta_tree;
   class subscriptionhandler* subHandler;
   class accesschecker* accessValidator;
-  string getVSSSpecificPath (string path, bool &isBranch, json& tree);
-  string getPathForMetadata(string path , bool &isBranch);
-  list<string>getPathForGet(string path , bool &isBranch);
-  json getPathForSet(string path,  json value);
+  string getVSSSpecificPath(string path, bool& isBranch, json& tree);
+  string getPathForMetadata(string path, bool& isBranch);
+  list<string> getPathForGet(string path, bool& isBranch);
+  json getPathForSet(string path, json value);
   string getReadablePath(string jsonpath);
+
  public:
-  vssdatabase(class subscriptionhandler* subHandle , class accesschecker* accValidator);
+  vssdatabase(class subscriptionhandler* subHandle,
+              class accesschecker* accValidator);
   void initJsonTree();
   json getMetaData(string path);
-  void setSignal(class wschannel& channel,string path, json value);
-  json getSignal(class wschannel& channel,string path); 
+  void setSignal(class wschannel& channel, string path, json value);
+  json getSignal(class wschannel& channel, string path);
 };
 #endif

--- a/w3c-visserver-api/include/wschannel.hpp
+++ b/w3c-visserver-api/include/wschannel.hpp
@@ -15,53 +15,32 @@
 #define __WSCHANNEL_H__
 
 #include <stdint.h>
-#include <string>
 #include <jsoncons/json.hpp>
-
+#include <string>
 
 using namespace std;
 using namespace jsoncons;
 using jsoncons::json;
 
 class wschannel {
-
-private:
+ private:
   uint32_t connectionID;
   bool authorized = false;
   string authToken;
   json permissions;
 
+ public:
+  void setConnID(uint32_t conID) { connectionID = conID; }
+  void setAuthorized(bool isauth) { authorized = isauth; }
+  void setAuthToken(string tok) { authToken = tok; }
+  void setPermissions(json perm) { permissions = perm; }
 
-public:
+  uint32_t getConnID() { return connectionID; }
 
-  void setConnID(uint32_t conID) {
-      connectionID = conID;
-  }
-  void setAuthorized(bool isauth) {
-      authorized = isauth;
-  }
-  void setAuthToken(string tok) {
-      authToken = tok;
-  }
-  void setPermissions(json perm) {
-      permissions = perm;
-  }
-  
-  uint32_t getConnID() {
-    return connectionID;
-  }
+  bool isAuthorized() { return authorized; }
 
-  bool isAuthorized() {
-    return authorized;
-  }
+  string getAuthToken() { return authToken; }
 
-  string getAuthToken() {
-   return authToken;
-  }
-
-  json getPermissions() {
-   return permissions;
-  }
-  
+  json getPermissions() { return permissions; }
 };
 #endif

--- a/w3c-visserver-api/include/wsserver.hpp
+++ b/w3c-visserver-api/include/wsserver.hpp
@@ -11,13 +11,13 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include "server_wss.hpp"
-#include "vsscommandprocessor.hpp"
-#include "subscriptionhandler.hpp"
-#include "vssdatabase.hpp"
-#include "authenticator.hpp"
-#include "visconf.hpp"
 #include "accesschecker.hpp"
+#include "authenticator.hpp"
+#include "server_wss.hpp"
+#include "subscriptionhandler.hpp"
+#include "visconf.hpp"
+#include "vsscommandprocessor.hpp"
+#include "vssdatabase.hpp"
 
 using namespace std;
 
@@ -28,26 +28,22 @@ using WssServer = SimpleWeb::SocketServer<SimpleWeb::WSS>;
 using WsServer = SimpleWeb::SocketServer<SimpleWeb::WS>;
 
 class wsserver {
-  private:
-    
-    WssServer* secureServer;
-    WsServer*  insecureServer;
-    bool isSecure;
-    
+ private:
+  WssServer* secureServer;
+  WsServer* insecureServer;
+  bool isSecure;
 
-  public:
-    
-    class vsscommandprocessor* cmdProcessor;
-    class subscriptionhandler* subHandler;
-    class authenticator* tokenValidator;
-    class vssdatabase* database;
-    class accesschecker* accessCheck;
+ public:
+  class vsscommandprocessor* cmdProcessor;
+  class subscriptionhandler* subHandler;
+  class authenticator* tokenValidator;
+  class vssdatabase* database;
+  class accesschecker* accessCheck;
 
-    wsserver(int port, bool secure);
-    ~wsserver();
-    void startServer(string endpointName);
-    void sendToConnection(uint32_t connID, string message);
-    void start();
-
+  wsserver(int port, bool secure);
+  ~wsserver();
+  void startServer(string endpointName);
+  void sendToConnection(uint32_t connID, string message);
+  void start();
 };
 #endif

--- a/w3c-visserver-api/src/accesschecker.cpp
+++ b/w3c-visserver-api/src/accesschecker.cpp
@@ -12,45 +12,45 @@
  * *****************************************************************************
  */
 
-#include"accesschecker.hpp"
+#include "accesschecker.hpp"
 
 using namespace std;
 
-accesschecker::accesschecker(class  authenticator* vdator) {
-   tokenValidator = vdator;
+accesschecker::accesschecker(class authenticator* vdator) {
+  tokenValidator = vdator;
 }
 
 // check the permissions json in wschannel if path has read access
-bool accesschecker::checkReadAccess(class wschannel& channel , string path) {
-   json permissions = channel.getPermissions();
-   string perm = permissions.get_with_default(path, "");
-  
-   if(perm == "r" || perm == "rw" || perm == "wr") {
-      return true;
-   }
-   return false;
-} 
+bool accesschecker::checkReadAccess(class wschannel& channel, string path) {
+  json permissions = channel.getPermissions();
+  string perm = permissions.get_with_default(path, "");
+
+  if (perm == "r" || perm == "rw" || perm == "wr") {
+    return true;
+  }
+  return false;
+}
 
 // check the permissions json in wschannel if path has write access
-bool accesschecker::checkWriteAccess (class wschannel& channel, string path) {
-   json permissions = channel.getPermissions();
-   string perm = permissions.get_with_default(path, "");
-  
-   if(perm == "w" || perm == "rw" || perm == "wr") {
-      return true;
-   }
-   return false;
+bool accesschecker::checkWriteAccess(class wschannel& channel, string path) {
+  json permissions = channel.getPermissions();
+  string perm = permissions.get_with_default(path, "");
+
+  if (perm == "w" || perm == "rw" || perm == "wr") {
+    return true;
+  }
+  return false;
 }
 
-// Checks if all the paths have write access.If even 1 path in the list does not have write access, this method returns false.
-bool accesschecker::checkPathWriteAccess (class wschannel& channel, json paths) {
-   for( int i=0 ; i< paths.size() ; i++) {
-      json item = paths[i];
-      string jPath = item["path"].as<string>();
-      if(!checkWriteAccess(channel , jPath)) {
-         return false;
-      }
-   }
-   return true;
+// Checks if all the paths have write access.If even 1 path in the list does not
+// have write access, this method returns false.
+bool accesschecker::checkPathWriteAccess(class wschannel& channel, json paths) {
+  for (int i = 0; i < paths.size(); i++) {
+    json item = paths[i];
+    string jPath = item["path"].as<string>();
+    if (!checkWriteAccess(channel, jPath)) {
+      return false;
+    }
+  }
+  return true;
 }
-

--- a/w3c-visserver-api/src/authenticator.cpp
+++ b/w3c-visserver-api/src/authenticator.cpp
@@ -11,107 +11,105 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-# include "authenticator.hpp"
-#include <iostream>
+#include "authenticator.hpp"
 #include <fstream>
+#include <iostream>
 
-
-authenticator::authenticator( string secretkey, string algo) {
-   algorithm = algo; 
-   key = secretkey;
-
+authenticator::authenticator(string secretkey, string algo) {
+  algorithm = algo;
+  key = secretkey;
 }
 
-string getPublicKey (string fileName) {
-  std::ifstream fileStream (fileName);
-  std::string key( (std::istreambuf_iterator<char>(fileStream)),
-                       (std::istreambuf_iterator<char>()));
+string getPublicKey(string fileName) {
+  std::ifstream fileStream(fileName);
+  std::string key((std::istreambuf_iterator<char>(fileStream)),
+                  (std::istreambuf_iterator<char>()));
 
   return key;
 }
 
 // utility method to validate token.
-int validateToken (wschannel &channel , string authToken) {
+int validateToken(wschannel& channel, string authToken) {
   auto decoded = jwt::decode(authToken);
   json claims;
-  for(auto& e : decoded.get_payload_claims()) {
-      std::cout << e.first << " = " << e.second.to_json() << std::endl;
-      claims[e.first] = e.second.to_json().to_str();
+  for (auto& e : decoded.get_payload_claims()) {
+    std::cout << e.first << " = " << e.second.to_json() << std::endl;
+    claims[e.first] = e.second.to_json().to_str();
   }
 
-   string rsa_pub_key = getPublicKey("jwt.pub.key");
-   auto verifier =jwt::verify()
-   .allow_algorithm(jwt::algorithm::rs256(rsa_pub_key, "", "", ""));
-  
+  string rsa_pub_key = getPublicKey("jwt.pub.key");
+  auto verifier = jwt::verify().allow_algorithm(
+      jwt::algorithm::rs256(rsa_pub_key, "", "", ""));
+
   try {
-      verifier.verify(decoded);
+    verifier.verify(decoded);
   } catch (const std::runtime_error& e) {
-      cout << "authenticator::validate: "<< e.what() << " Exception occured while authentication. Token is not valid!"<<endl;
-      return -1; 
+    cout << "authenticator::validate: " << e.what()
+         << " Exception occured while authentication. Token is not valid!"
+         << endl;
+    return -1;
   }
 
   int ttl = claims["exp"].as<int>();
   channel.setAuthorized(true);
   channel.setAuthToken(authToken);
   return ttl;
-
 }
 
-// validates the token against expiry date/time. should be extended to check some other claims.
-int authenticator::validate (wschannel &channel ,vssdatabase* db,  string authToken) {
-  
+// validates the token against expiry date/time. should be extended to check
+// some other claims.
+int authenticator::validate(wschannel& channel, vssdatabase* db,
+                            string authToken) {
   int ttl = validateToken(channel, authToken);
-  if(ttl > 0)
-     resolvePermissions(channel, db);
+  if (ttl > 0) resolvePermissions(channel, db);
 
   return ttl;
 }
 
-
-// Checks if the token is still valid for the requests from the channel(client). Internally check this before publishing messages for previously subscribed signals.
-bool authenticator::isStillValid (wschannel &channel) {
-
+// Checks if the token is still valid for the requests from the channel(client).
+// Internally check this before publishing messages for previously subscribed
+// signals.
+bool authenticator::isStillValid(wschannel& channel) {
   string token = channel.getAuthToken();
-  int ret = validateToken (channel , token);
-  
-   if( ret == -1 ) {
-      channel.setAuthorized(false);
-      return false;
-   } else {
-      return true;
-   }
+  int ret = validateToken(channel, token);
+
+  if (ret == -1) {
+    channel.setAuthorized(false);
+    return false;
+  } else {
+    return true;
+  }
 }
 
-
 // **Do this only once for authenticate request**
-// resolves the permission in the JWT token and store the absolute path to the signals in permissions JSON in wschannel.
-json authenticator::resolvePermissions(wschannel &channel, vssdatabase* database ) {
-
+// resolves the permission in the JWT token and store the absolute path to the
+// signals in permissions JSON in wschannel.
+json authenticator::resolvePermissions(wschannel& channel,
+                                       vssdatabase* database) {
   string authToken = channel.getAuthToken();
   auto decoded = jwt::decode(authToken);
   json claims;
-  for(auto& e : decoded.get_payload_claims()) {
-      std::cout << e.first << " = " << e.second.to_json() << std::endl;
-      stringstream value; 
-      value << e.second.to_json();
-      claims[e.first] = json::parse(value.str());
+  for (auto& e : decoded.get_payload_claims()) {
+    std::cout << e.first << " = " << e.second.to_json() << std::endl;
+    stringstream value;
+    value << e.second.to_json();
+    claims[e.first] = json::parse(value.str());
   }
-  
+
   if (claims.has_key("w3c-vss")) {
     json tokenPermJson = claims["w3c-vss"];
     json permissions;
-    for(auto path : tokenPermJson.object_range()) {
-        bool isBranch;
-        string pathString(path.key());
-        list<string> paths = database->getPathForGet(pathString, isBranch);
-        
-        for(string verifiedPath : paths) {
-            permissions.insert_or_assign(verifiedPath, path.value());
-        }   
+    for (auto path : tokenPermJson.object_range()) {
+      bool isBranch;
+      string pathString(path.key());
+      list<string> paths = database->getPathForGet(pathString, isBranch);
+
+      for (string verifiedPath : paths) {
+        permissions.insert_or_assign(verifiedPath, path.value());
+      }
     }
     channel.setPermissions(permissions);
   } else {
     return json::parse("{}");
   }
-
 }

--- a/w3c-visserver-api/src/main.cpp
+++ b/w3c-visserver-api/src/main.cpp
@@ -12,7 +12,6 @@
  * *****************************************************************************
  */
 
-
 #include "wsserver.hpp"
 
 #define PORT 8090
@@ -21,11 +20,11 @@
  * @brief  Test main.
  * @return
  */
-int main(int argc, char* argv[])
-{
- 
-        wsserver server(PORT, true);
-        server.start();
+int main(int argc, char* argv[]) {
+  wsserver server(PORT, true);
+  server.start();
 
-      while (1) { usleep (1000000); };
+  while (1) {
+    usleep(1000000);
+  };
 }

--- a/w3c-visserver-api/src/signing.cpp
+++ b/w3c-visserver-api/src/signing.cpp
@@ -21,19 +21,17 @@
  Constructor
 */
 signing::signing() {
-   getKey(PRIVATEFILENAME);
-   getPublicKey(PUBLICFILENAME); 
-   
+  getKey(PRIVATEFILENAME);
+  getPublicKey(PUBLICFILENAME);
 }
 
 /**
  Get the private key for signing.
 */
-string signing::getKey (string fileName) {
-  
+string signing::getKey(string fileName) {
   std::ifstream fileStream(fileName);
   std::string privatekey((std::istreambuf_iterator<char>(fileStream)),
-                          (std::istreambuf_iterator<char>()));
+                         (std::istreambuf_iterator<char>()));
   key = privatekey;
   return key;
 }
@@ -41,11 +39,10 @@ string signing::getKey (string fileName) {
 /**
  Get the public key for signing.
 */
-string signing::getPublicKey (string fileName) {
-
-  std::ifstream fileStream (fileName);
-  std::string privatekey( (std::istreambuf_iterator<char>(fileStream)),
-                       (std::istreambuf_iterator<char>()));
+string signing::getPublicKey(string fileName) {
+  std::ifstream fileStream(fileName);
+  std::string privatekey((std::istreambuf_iterator<char>(fileStream)),
+                         (std::istreambuf_iterator<char>()));
   pubkey = privatekey;
   return pubkey;
 }
@@ -54,64 +51,63 @@ string signing::getPublicKey (string fileName) {
  Signs the JSON and returns a string token
 */
 string signing::sign(json data) {
-   auto algo = jwt::algorithm::rs256(pubkey, key, "", "");
-   auto encode = [](const std::string& data) {
-	auto base = base::encode<alphabet::base64url>(data);
-	auto pos = base.find(alphabet::base64url::fill());
-	base = base.substr(0, pos);
-	return base;
-   };
+  auto algo = jwt::algorithm::rs256(pubkey, key, "", "");
+  auto encode = [](const std::string& data) {
+    auto base = base::encode<alphabet::base64url>(data);
+    auto pos = base.find(alphabet::base64url::fill());
+    base = base.substr(0, pos);
+    return base;
+  };
 
-   string header_json (R"({
+  string header_json(R"({
 		"alg": "RS256",
 		"typ": "GENIVI-VSS"
    })");
 
-   std::string header = encode(header_json);
-   std::string payload = encode(data.as<string>());
-   std::string token = header + "." + payload;
+  std::string header = encode(header_json);
+  std::string payload = encode(data.as<string>());
+  std::string token = header + "." + payload;
 
-   return token + "." + encode(algo.sign(token));
+  return token + "." + encode(algo.sign(token));
 }
 
 /**
  Signs the JSON and returns a string token
 */
 string signing::sign(string data) {
-   auto algo = jwt::algorithm::rs256(pubkey, key, "", "");
-   auto encode = [](const std::string& data) {
-	auto base = base::encode<alphabet::base64url>(data);
-	auto pos = base.find(alphabet::base64url::fill());
-	base = base.substr(0, pos);
-	return base;
-   };
+  auto algo = jwt::algorithm::rs256(pubkey, key, "", "");
+  auto encode = [](const std::string& data) {
+    auto base = base::encode<alphabet::base64url>(data);
+    auto pos = base.find(alphabet::base64url::fill());
+    base = base.substr(0, pos);
+    return base;
+  };
 
-   string header_json (R"({
+  string header_json(R"({
 		"alg": "RS256",
 		"typ": "GENIVI-VSS"
    })");
 
-   std::string header = encode(header_json);
-   std::string payload = encode(data);
-   std::string token = header + "." + payload;
+  std::string header = encode(header_json);
+  std::string payload = encode(data);
+  std::string token = header + "." + payload;
 
-   return token + "." + encode(algo.sign(token));
+  return token + "." + encode(algo.sign(token));
 }
 
 #ifdef UNIT_TEST
 string signing::decode(string signedData) {
-   
-   auto verify = jwt::verify()
-		.allow_algorithm(jwt::algorithm::rs256(pubkey, "", "", ""));
+  auto verify =
+      jwt::verify().allow_algorithm(jwt::algorithm::rs256(pubkey, "", "", ""));
 
-   auto decoded_token = jwt::decode(signedData);
-   try {
-      verify.verify(decoded_token);
-   } catch (exception &e) {
-      cout <<"Error while verfying JSON signing " << e.what() << endl;
-      return "";
-   }
-   
-   return decoded_token.get_payload();
-}  
+  auto decoded_token = jwt::decode(signedData);
+  try {
+    verify.verify(decoded_token);
+  } catch (exception& e) {
+    cout << "Error while verfying JSON signing " << e.what() << endl;
+    return "";
+  }
+
+  return decoded_token.get_payload();
+}
 #endif

--- a/w3c-visserver-api/src/subscriptionhandler.cpp
+++ b/w3c-visserver-api/src/subscriptionhandler.cpp
@@ -13,161 +13,159 @@
  */
 #include "subscriptionhandler.hpp"
 
-
 pthread_mutex_t subMutex;
 
-
-subscriptionhandler::subscriptionhandler(class wsserver* wserver, class authenticator* authenticate, class accesschecker* checkAcc) {
-   server = wserver;
-   validator = authenticate;
-   checkAccess = checkAcc;
-   pthread_mutex_init (&subMutex, NULL);
-   threadRun = true;
-   startThread();
+subscriptionhandler::subscriptionhandler(class wsserver* wserver,
+                                         class authenticator* authenticate,
+                                         class accesschecker* checkAcc) {
+  server = wserver;
+  validator = authenticate;
+  checkAccess = checkAcc;
+  pthread_mutex_init(&subMutex, NULL);
+  threadRun = true;
+  startThread();
 }
 
+uint32_t subscriptionhandler::subscribe(class wschannel& channel,
+                                        class vssdatabase* db,
+                                        uint32_t channelID, string path) {
+  // generate subscribe ID "randomly".
+  uint32_t subId = rand() % 9999999;
+  // embed connection ID into subID.
+  subId = channelID + subId;
 
-uint32_t subscriptionhandler::subscribe (class wschannel& channel, class vssdatabase* db, uint32_t channelID, string path) {
- 
-    // generate subscribe ID "randomly".
-    uint32_t subId = rand() % 9999999;
-    // embed connection ID into subID.
-    subId = channelID + subId;
+  bool isBranch = false;
+  string jPath = db->getVSSSpecificPath(path, isBranch, db->data_tree);
 
-   
-    bool isBranch = false;
-    string jPath = db->getVSSSpecificPath(path, isBranch, db->data_tree);
-    
-    if(jPath == "") {
-       throw noPathFoundonTree(path);
-    } else if (!checkAccess->checkReadAccess(channel, jPath)) {
-        stringstream msg;
-        msg << "no permission to subscribe to path" ;
-        throw noPermissionException(msg.str());
-    }
+  if (jPath == "") {
+    throw noPathFoundonTree(path);
+  } else if (!checkAccess->checkReadAccess(channel, jPath)) {
+    stringstream msg;
+    msg << "no permission to subscribe to path";
+    throw noPermissionException(msg.str());
+  }
 
-    int clientID = channelID/CLIENT_MASK;
-    json resArray = json_query(db->data_tree , jPath);
+  int clientID = channelID / CLIENT_MASK;
+  json resArray = json_query(db->data_tree, jPath);
 
-    if(resArray.is_array() && resArray.size() == 1) {
-
-       json result = resArray[0];
-       int sigID = result["id"].as<int>();
+  if (resArray.is_array() && resArray.size() == 1) {
+    json result = resArray[0];
+    int sigID = result["id"].as<int>();
 #ifdef DEBUG
-       if(subscribeHandle[sigID][clientID] != 0) {
-          cout <<"subscriptionhandler::subscribe: Updating the previous subscribe ID with a new one"<< endl;
-       }
+    if (subscribeHandle[sigID][clientID] != 0) {
+      cout << "subscriptionhandler::subscribe: Updating the previous subscribe "
+              "ID with a new one"
+           << endl;
+    }
 #endif
-       subscribeHandle[sigID][clientID] = subId;
-       return subId;        
-     } else if(resArray.is_array()) {
-       cout <<resArray.size()<<"subscriptionhandler::subscribe :signals found in path" << path <<". Subscribe works for 1 signal at a time" << endl;
-       stringstream msg;
-       msg << "signals found in path" << path <<". Subscribe works for 1 signal at a time" ;
-       throw noPathFoundonTree(msg.str());
-     } else {
-       cout <<"subscriptionhandler::subscribe: some error occured while adding subscription"<<endl;
-       stringstream msg;
-       msg << "some error occured while adding subscription for path = " << path ;
-       throw genException(msg.str());
-     }
-}
-   
-int subscriptionhandler::unsubscribe (uint32_t subscribeID ) {
-  int clientID = subscribeID/CLIENT_MASK;
-    for(int i=0 ;i < MAX_SIGNALS ; i++) {
-       if(subscribeHandle[i][clientID] == subscribeID) {
-               subscribeHandle[i][clientID] = 0;
-               return 0;
-        } 
-     }
-   return -1;
+    subscribeHandle[sigID][clientID] = subId;
+    return subId;
+  } else if (resArray.is_array()) {
+    cout << resArray.size()
+         << "subscriptionhandler::subscribe :signals found in path" << path
+         << ". Subscribe works for 1 signal at a time" << endl;
+    stringstream msg;
+    msg << "signals found in path" << path
+        << ". Subscribe works for 1 signal at a time";
+    throw noPathFoundonTree(msg.str());
+  } else {
+    cout << "subscriptionhandler::subscribe: some error occured while adding "
+            "subscription"
+         << endl;
+    stringstream msg;
+    msg << "some error occured while adding subscription for path = " << path;
+    throw genException(msg.str());
+  }
 }
 
-int subscriptionhandler::unsubscribeAll ( uint32_t connectionID) {
-   for(int i=0 ;i < MAX_SIGNALS ; i++) {
-          subscribeHandle[i][connectionID] = 0;
-   }
-#ifdef DEBUG 
-   cout <<"subscriptionhandler::unsubscribeAll: Removed all subscriptions for client with ID ="<< connectionID*CLIENT_MASK << endl;
+int subscriptionhandler::unsubscribe(uint32_t subscribeID) {
+  int clientID = subscribeID / CLIENT_MASK;
+  for (int i = 0; i < MAX_SIGNALS; i++) {
+    if (subscribeHandle[i][clientID] == subscribeID) {
+      subscribeHandle[i][clientID] = 0;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+int subscriptionhandler::unsubscribeAll(uint32_t connectionID) {
+  for (int i = 0; i < MAX_SIGNALS; i++) {
+    subscribeHandle[i][connectionID] = 0;
+  }
+#ifdef DEBUG
+  cout << "subscriptionhandler::unsubscribeAll: Removed all subscriptions for "
+          "client with ID ="
+       << connectionID * CLIENT_MASK << endl;
 #endif
-   return 0;
+  return 0;
 }
 
-int subscriptionhandler::update (int signalID, json value) {
-
-  for(int i=0 ; i< MAX_CLIENTS ; i++) {
+int subscriptionhandler::update(int signalID, json value) {
+  for (int i = 0; i < MAX_CLIENTS; i++) {
     uint32_t subID = subscribeHandle[signalID][i];
-     if( subID != 0) {
-        pthread_mutex_lock (&subMutex);
-        pair<uint32_t, json> newSub;
-        newSub = std::make_pair(subID, value);
-        buffer.push(newSub);
-        pthread_mutex_unlock (&subMutex);
-     }
+    if (subID != 0) {
+      pthread_mutex_lock(&subMutex);
+      pair<uint32_t, json> newSub;
+      newSub = std::make_pair(subID, value);
+      buffer.push(newSub);
+      pthread_mutex_unlock(&subMutex);
+    }
   }
   return 0;
 }
 
 class wsserver* subscriptionhandler::getServer() {
-    return server;
-}
-   
-int subscriptionhandler::update (string path, json value) {
-  return 0;
+  return server;
 }
 
-void* subThread(void * instance) {
-    subscriptionhandler* handler = (subscriptionhandler*) instance;
+int subscriptionhandler::update(string path, json value) { return 0; }
+
+void* subThread(void* instance) {
+  subscriptionhandler* handler = (subscriptionhandler*)instance;
 #ifdef DEBUG
-    cout << "SubscribeThread: Started Subscription Thread!"<<endl;
+  cout << "SubscribeThread: Started Subscription Thread!" << endl;
 #endif
-    while (handler->isThreadRunning()) {
-          
-       pthread_mutex_lock (&subMutex);
-       if(handler->buffer.size() > 0) {
+  while (handler->isThreadRunning()) {
+    pthread_mutex_lock(&subMutex);
+    if (handler->buffer.size() > 0) {
+      pair<uint32_t, json> newSub = handler->buffer.front();
+      handler->buffer.pop();
 
-          pair<uint32_t, json> newSub = handler->buffer.front();
-          handler->buffer.pop();
-          
+      uint32_t subID = newSub.first;
+      json value = newSub.second;
 
-          uint32_t subID = newSub.first;
-          json value = newSub.second;
+      json answer;
+      answer["action"] = "subscribe";
+      answer["subscriptionId"] = subID;
+      answer.insert_or_assign("value", value);
+      answer["timestamp"] = time(NULL);
 
-          json answer;
-          answer["action"] = "subscribe";
-          answer["subscriptionId"] = subID;
-          answer.insert_or_assign("value", value);
-          answer["timestamp"] = time(NULL);
+      stringstream ss;
+      ss << pretty_print(answer);
+      string message = ss.str();
 
-          stringstream ss;
-          ss << pretty_print(answer);
-          string message = ss.str();
-  
-          uint32_t connectionID = (subID/CLIENT_MASK) * CLIENT_MASK;
-          handler->getServer()->sendToConnection(connectionID , message);
-       }
-        pthread_mutex_unlock (&subMutex);
-        // sleep 10 ms
-        usleep(10000);
-     }
-     cout << "SubscribeThread: Subscription handler thread stopped running"<<endl;
+      uint32_t connectionID = (subID / CLIENT_MASK) * CLIENT_MASK;
+      handler->getServer()->sendToConnection(connectionID, message);
+    }
+    pthread_mutex_unlock(&subMutex);
+    // sleep 10 ms
+    usleep(10000);
+  }
+  cout << "SubscribeThread: Subscription handler thread stopped running"
+       << endl;
 }
 
 int subscriptionhandler::startThread() {
-
-    pthread_t subscription_thread;
-    if(pthread_create(&subscription_thread, NULL, &subThread, this)) {
-      cout << "subscriptionhandler::startThread: Error creating subscription handler thread"<<endl;
-      return 1;
-    }
+  pthread_t subscription_thread;
+  if (pthread_create(&subscription_thread, NULL, &subThread, this)) {
+    cout << "subscriptionhandler::startThread: Error creating subscription "
+            "handler thread"
+         << endl;
+    return 1;
+  }
 }
 
-int subscriptionhandler::stopThread() {  
-   threadRun = false;
-}
+int subscriptionhandler::stopThread() { threadRun = false; }
 
-
-bool subscriptionhandler::isThreadRunning() {
-   return threadRun; 
-} 
+bool subscriptionhandler::isThreadRunning() { return threadRun; }

--- a/w3c-visserver-api/src/vsscommandprocessor.cpp
+++ b/w3c-visserver-api/src/vsscommandprocessor.cpp
@@ -13,13 +13,13 @@
  */
 
 #include "vsscommandprocessor.hpp"
+#include <stdint.h>
 #include <iostream>
 #include <sstream>
-#include <stdint.h>
-#include "vssdatabase.hpp"
+#include "exception.hpp"
 #include "server_ws.hpp"
 #include "visconf.hpp"
-#include "exception.hpp"
+#include "vssdatabase.hpp"
 
 #ifdef JSON_SIGNING_ON
 #include "signing.hpp"
@@ -28,359 +28,358 @@
 using namespace std;
 
 string malFormedRequestResponse(uint32_t request_id, const string action) {
-   json answer;
-   answer["action"] = action;
-   answer["requestId"]= request_id;
-   json error;
-   error["number"] = 400;
-   error["reason"] = "Request malformed";
-   error["message"] = "Request malformed";
-   answer["error"] = error;
-   answer["timestamp"] = time(NULL);
-   stringstream ss; 
-   ss << pretty_print(answer);
-   return ss.str();
+  json answer;
+  answer["action"] = action;
+  answer["requestId"] = request_id;
+  json error;
+  error["number"] = 400;
+  error["reason"] = "Request malformed";
+  error["message"] = "Request malformed";
+  answer["error"] = error;
+  answer["timestamp"] = time(NULL);
+  stringstream ss;
+  ss << pretty_print(answer);
+  return ss.str();
 }
 
 /** A API call requested a non-existant path */
-string pathNotFoundResponse(uint32_t request_id, const string action, const string path) {
-
-   json answer;
-   answer["action"] = action;
-   answer["requestId"]= request_id;
-   json error;
-   error["number"] = 404;
-   error["reason"] = "Path not found";
-   error["message"] = "I can not find "+path+" in my db";
-   answer["error"] = error;
-   answer["timestamp"] = time(NULL);
-   stringstream ss; 
-   ss << pretty_print(answer);
-   return ss.str();
+string pathNotFoundResponse(uint32_t request_id, const string action,
+                            const string path) {
+  json answer;
+  answer["action"] = action;
+  answer["requestId"] = request_id;
+  json error;
+  error["number"] = 404;
+  error["reason"] = "Path not found";
+  error["message"] = "I can not find " + path + " in my db";
+  answer["error"] = error;
+  answer["timestamp"] = time(NULL);
+  stringstream ss;
+  ss << pretty_print(answer);
+  return ss.str();
 }
 
-string noAccessResponse (uint32_t request_id, const string action , string message) {
-   json result;
-   json error;
-   result["action"] =action;
-   result["requestId"] = request_id; 
-   error["number"] = 403;
-   error["reason"] = "Forbidden";
-   error["message"] = message;
-   result["error"] = error;
-   result["timestamp"]= time(NULL);
-   std::stringstream ss;
-   ss << pretty_print(result);
-   return ss.str();
+string noAccessResponse(uint32_t request_id, const string action,
+                        string message) {
+  json result;
+  json error;
+  result["action"] = action;
+  result["requestId"] = request_id;
+  error["number"] = 403;
+  error["reason"] = "Forbidden";
+  error["message"] = message;
+  result["error"] = error;
+  result["timestamp"] = time(NULL);
+  std::stringstream ss;
+  ss << pretty_print(result);
+  return ss.str();
 }
 
-
-string valueOutOfBoundsResponse(uint32_t request_id, const string action, const string message) {
-
-   json answer;
-   answer["action"] = action;
-   answer["requestId"]= request_id;
-   json error;
-   error["number"] = 400;
-   error["reason"] = "Value passed is out of bounds";
-   error["message"] = message;
-   answer["error"] = error;
-   answer["timestamp"] = time(NULL);
-   stringstream ss; 
-   ss << pretty_print(answer);
-   return ss.str();
+string valueOutOfBoundsResponse(uint32_t request_id, const string action,
+                                const string message) {
+  json answer;
+  answer["action"] = action;
+  answer["requestId"] = request_id;
+  json error;
+  error["number"] = 400;
+  error["reason"] = "Value passed is out of bounds";
+  error["message"] = message;
+  answer["error"] = error;
+  answer["timestamp"] = time(NULL);
+  stringstream ss;
+  ss << pretty_print(answer);
+  return ss.str();
 }
 
-
-
-vsscommandprocessor::vsscommandprocessor(class vssdatabase* dbase, class  authenticator* vdator , class subscriptionhandler* subhandler) {
-   database = dbase;
-   tokenValidator = vdator;
-   subHandler = subhandler;
-   accessValidator = new accesschecker(tokenValidator); 
+vsscommandprocessor::vsscommandprocessor(
+    class vssdatabase *dbase, class authenticator *vdator,
+    class subscriptionhandler *subhandler) {
+  database = dbase;
+  tokenValidator = vdator;
+  subHandler = subhandler;
+  accessValidator = new accesschecker(tokenValidator);
 #ifdef JSON_SIGNING_ON
-   signer = new signing();
+  signer = new signing();
 #endif
 }
 
-
-string vsscommandprocessor::processGet(class wschannel& channel,uint32_t request_id, string path) {
-
+string vsscommandprocessor::processGet(class wschannel &channel,
+                                       uint32_t request_id, string path) {
 #ifdef DEBUG
-   cout<< "GET :: path received from client = "<< path <<endl;
+  cout << "GET :: path received from client = " << path << endl;
 #endif
-   json res;
-   try {
-      res = database->getSignal(channel,path);
-   } catch (noPermissionException &nopermission) {
-      cout << nopermission.what() << endl;
-      return noAccessResponse(request_id , "get" , nopermission.what());  
-   }
-   if(!res.has_key("value")) {
-      return pathNotFoundResponse(request_id, "get", path);
-   } else {
-      res["action"] = "get";
-      res["requestId"] = request_id;
-      res["timestamp"]= time(NULL);
-      stringstream ss; 
-      ss << pretty_print(res);
-      return ss.str();
-   }
+  json res;
+  try {
+    res = database->getSignal(channel, path);
+  } catch (noPermissionException &nopermission) {
+    cout << nopermission.what() << endl;
+    return noAccessResponse(request_id, "get", nopermission.what());
+  }
+  if (!res.has_key("value")) {
+    return pathNotFoundResponse(request_id, "get", path);
+  } else {
+    res["action"] = "get";
+    res["requestId"] = request_id;
+    res["timestamp"] = time(NULL);
+    stringstream ss;
+    ss << pretty_print(res);
+    return ss.str();
+  }
 }
 
-
-string vsscommandprocessor::processSet(class wschannel& channel,uint32_t request_id, string path, json value) {
-
+string vsscommandprocessor::processSet(class wschannel &channel,
+                                       uint32_t request_id, string path,
+                                       json value) {
 #ifdef DEBUG
-   cout<< "vsscommandprocessor::processSet: path received from client"<< path <<endl;
+  cout << "vsscommandprocessor::processSet: path received from client" << path
+       << endl;
 #endif
 
-   const char *path_c=path.c_str();
-   char * nonconst=strdup(path_c);
-   try {
-       database->setSignal(channel,path, value);
-   } catch ( genException &e ) {
-       cout << e.what() << endl;
-       json root;
-       json error;
+  const char *path_c = path.c_str();
+  char *nonconst = strdup(path_c);
+  try {
+    database->setSignal(channel, path, value);
+  } catch (genException &e) {
+    cout << e.what() << endl;
+    json root;
+    json error;
 
-       root["action"] = "set";
-       root["requestId"] = request_id;
+    root["action"] = "set";
+    root["requestId"] = request_id;
 
-       error["number"] = 401;
-       error["reason"] = "Unknown error";
-       error["message"] = e.what();
+    error["number"] = 401;
+    error["reason"] = "Unknown error";
+    error["message"] = e.what();
 
-       root["error"] = error;
-       root["timestamp"] = time(NULL);
+    root["error"] = error;
+    root["timestamp"] = time(NULL);
 
-       std::stringstream ss;
-       ss << pretty_print(root);
-       return ss.str();
-   } catch (noPathFoundonTree &e) {
-       cout << e.what() << endl;
-       return pathNotFoundResponse(request_id, "set", path);
-   } catch (outOfBoundException &outofboundExp) {
-       cout << outofboundExp.what() << endl;
-       return valueOutOfBoundsResponse(request_id ,"set",outofboundExp.what());
-   } catch (noPermissionException &nopermission) {
-       cout << nopermission.what() << endl;
-       return noAccessResponse(request_id , "set" , nopermission.what());
-   }
-   
-   
-   json answer;
-   answer["action"] ="set";
-   answer["requestId"] = request_id;
-   answer["timestamp"] = time(NULL);
-   
-   std::stringstream ss;
-   ss << pretty_print(answer);
-   return ss.str();    
+    std::stringstream ss;
+    ss << pretty_print(root);
+    return ss.str();
+  } catch (noPathFoundonTree &e) {
+    cout << e.what() << endl;
+    return pathNotFoundResponse(request_id, "set", path);
+  } catch (outOfBoundException &outofboundExp) {
+    cout << outofboundExp.what() << endl;
+    return valueOutOfBoundsResponse(request_id, "set", outofboundExp.what());
+  } catch (noPermissionException &nopermission) {
+    cout << nopermission.what() << endl;
+    return noAccessResponse(request_id, "set", nopermission.what());
+  }
+
+  json answer;
+  answer["action"] = "set";
+  answer["requestId"] = request_id;
+  answer["timestamp"] = time(NULL);
+
+  std::stringstream ss;
+  ss << pretty_print(answer);
+  return ss.str();
 }
 
-string vsscommandprocessor::processSubscribe(class wschannel& channel,uint32_t request_id, string path, uint32_t connectionID) {
-
+string vsscommandprocessor::processSubscribe(class wschannel &channel,
+                                             uint32_t request_id, string path,
+                                             uint32_t connectionID) {
 #ifdef DEBUG
-    cout<< "vsscommandprocessor::processSubscribe: path received from client for subscription"<< path<<endl;
+  cout << "vsscommandprocessor::processSubscribe: path received from client "
+          "for subscription"
+       << path << endl;
 #endif
-   
-      uint32_t subId = -1;
-      try {
-         subId = subHandler->subscribe(channel, database, connectionID , path);
-      } catch (noPathFoundonTree &noPathFound) {
-        cout << noPathFound.what() << endl;
-        return pathNotFoundResponse(request_id, "subscribe", path);
-      } catch (genException &outofboundExp) {
-        cout << outofboundExp.what() << endl;
-        return valueOutOfBoundsResponse(request_id ,"subscribe",outofboundExp.what());
-      } catch (noPermissionException &nopermission) {
-        cout << nopermission.what() << endl;
-        return noAccessResponse(request_id , "subscribe" , nopermission.what());
-      }
 
-    if( subId > 0) {
-       json answer;
-       answer["action"] = "subscribe";
-       answer["requestId"] = request_id;
-       answer["subscriptionId"] = subId;
-       answer["timestamp"] = time(NULL);
-   
-       std::stringstream ss;
-       ss << pretty_print(answer);
-       return ss.str();
+  uint32_t subId = -1;
+  try {
+    subId = subHandler->subscribe(channel, database, connectionID, path);
+  } catch (noPathFoundonTree &noPathFound) {
+    cout << noPathFound.what() << endl;
+    return pathNotFoundResponse(request_id, "subscribe", path);
+  } catch (genException &outofboundExp) {
+    cout << outofboundExp.what() << endl;
+    return valueOutOfBoundsResponse(request_id, "subscribe",
+                                    outofboundExp.what());
+  } catch (noPermissionException &nopermission) {
+    cout << nopermission.what() << endl;
+    return noAccessResponse(request_id, "subscribe", nopermission.what());
+  }
 
-    } else {
+  if (subId > 0) {
+    json answer;
+    answer["action"] = "subscribe";
+    answer["requestId"] = request_id;
+    answer["subscriptionId"] = subId;
+    answer["timestamp"] = time(NULL);
 
-       json root;
-       json error;
+    std::stringstream ss;
+    ss << pretty_print(answer);
+    return ss.str();
 
-       root["action"] = "subscribe";
-       root["requestId"] = request_id;
-       error["number"] = 400;
-       error["reason"] = "Bad Request";
-       error["message"] = "Unknown";
-        
-       root["error"] = error;
-       root["timestamp"] = time(NULL);
+  } else {
+    json root;
+    json error;
 
-       std::stringstream ss;
+    root["action"] = "subscribe";
+    root["requestId"] = request_id;
+    error["number"] = 400;
+    error["reason"] = "Bad Request";
+    error["message"] = "Unknown";
 
-       ss << pretty_print(root);
-       return ss.str();
+    root["error"] = error;
+    root["timestamp"] = time(NULL);
 
-    }
+    std::stringstream ss;
+
+    ss << pretty_print(root);
+    return ss.str();
+  }
 }
 
-string vsscommandprocessor::processUnsubscribe(uint32_t request_id, uint32_t subscribeID) {
+string vsscommandprocessor::processUnsubscribe(uint32_t request_id,
+                                               uint32_t subscribeID) {
+  int res = subHandler->unsubscribe(subscribeID);
+  if (res == 0) {
+    json answer;
+    answer["action"] = "unsubscribe";
+    answer["requestId"] = request_id;
+    answer["subscriptionId"] = subscribeID;
+    answer["timestamp"] = time(NULL);
 
-   int res = subHandler->unsubscribe(subscribeID);
-   if( res == 0) {
-       json answer;
-       answer["action"] = "unsubscribe";
-       answer["requestId"] = request_id;
-       answer["subscriptionId"] = subscribeID;
-       answer["timestamp"] = time(NULL);
-   
-       std::stringstream ss;
-       ss << pretty_print(answer);
-       return ss.str();
+    std::stringstream ss;
+    ss << pretty_print(answer);
+    return ss.str();
 
-    } else {
+  } else {
+    json root;
+    json error;
 
+    root["action"] = "unsubscribe";
+    root["requestId"] = request_id;
+    error["number"] = 400;
+    error["reason"] = "Unknown error";
+    error["message"] = "Error while unsubscribing";
 
-       json root;
-       json error;
+    root["error"] = error;
+    root["timestamp"] = time(NULL);
 
-       root["action"] = "unsubscribe";
-       root["requestId"] = request_id;
-       error["number"] = 400;
-       error["reason"] = "Unknown error";
-       error["message"] = "Error while unsubscribing";
-
-       root["error"] = error;
-       root["timestamp"] = time(NULL);
-
-       std::stringstream ss;
-       ss << pretty_print(root);
-       return ss.str();
-    }
-
+    std::stringstream ss;
+    ss << pretty_print(root);
+    return ss.str();
+  }
 }
 
-string vsscommandprocessor::processGetMetaData(uint32_t request_id, string path) {
-	json st = database->getMetaData(path);
-	
-	json result;
-	result["action"] ="getMetadata";
-        result["requestId"] = request_id; 
-        result["metadata"]= st;
-	result["timestamp"]= time(NULL);
-	
-	std::stringstream ss;
-   	ss << pretty_print(result);
-   	
-	return ss.str(); 
+string vsscommandprocessor::processGetMetaData(uint32_t request_id,
+                                               string path) {
+  json st = database->getMetaData(path);
+
+  json result;
+  result["action"] = "getMetadata";
+  result["requestId"] = request_id;
+  result["metadata"] = st;
+  result["timestamp"] = time(NULL);
+
+  std::stringstream ss;
+  ss << pretty_print(result);
+
+  return ss.str();
 }
 
-string vsscommandprocessor::processAuthorize (class wschannel& channel,uint32_t request_id, string token) {
+string vsscommandprocessor::processAuthorize(class wschannel &channel,
+                                             uint32_t request_id,
+                                             string token) {
+  int ttl = tokenValidator->validate(channel, database, token);
 
+  if (ttl == -1) {
+    json result;
+    json error;
+    result["action"] = "authorize";
+    result["requestId"] = request_id;
+    error["number"] = 401;
+    error["reason"] = "Invalid Token";
+    error["message"] = "Check the JWT token passed";
 
-        int ttl = tokenValidator->validate(channel,database,token);
+    result["error"] = error;
+    result["timestamp"] = time(NULL);
 
-        if( ttl == -1) {
-           json result;
-           json error;
-	   result["action"] ="authorize";
-           result["requestId"] = request_id; 
-           error["number"] = 401;
-           error["reason"] = "Invalid Token";
-           error["message"] = "Check the JWT token passed";
+    std::stringstream ss;
+    ss << pretty_print(result);
+    return ss.str();
 
-	   result["error"] = error;
-	   result["timestamp"]= time(NULL);
-	
-	   std::stringstream ss;
-   	   ss << pretty_print(result);
-	   return ss.str();
+  } else {
+    json result;
+    result["action"] = "authorize";
+    result["requestId"] = request_id;
+    result["TTL"] = ttl;
+    result["timestamp"] = time(NULL);
 
-        } else {
-
-           json result;
-	   result["action"] ="authorize";
-           result["requestId"] = request_id; 
-           result["TTL"]= ttl;
-	   result["timestamp"]= time(NULL);
-	
-	   std::stringstream ss;
-   	   ss << pretty_print(result);
-	   return ss.str();
-        } 
-
+    std::stringstream ss;
+    ss << pretty_print(result);
+    return ss.str();
+  }
 }
 
+string vsscommandprocessor::processQuery(string req_json,
+                                         class wschannel &channel) {
+  json root;
+  string response;
+  root = json::parse(req_json);
+  string action = root["action"].as<string>();
 
-string vsscommandprocessor::processQuery(string req_json , class wschannel& channel) {
-
-	json root;
-        string response;
-        root = json::parse(req_json);
-	string action = root["action"].as<string>();
-	
-        if ( action == "authorize") {
-                string token = root["tokens"].as<string>();
-                uint32_t request_id = root["requestId"].as<int>();
+  if (action == "authorize") {
+    string token = root["tokens"].as<string>();
+    uint32_t request_id = root["requestId"].as<int>();
 #ifdef DEBUG
-		cout << "vsscommandprocessor::processQuery: authorize query with token = " << token << " with request id " <<  request_id << endl;
+    cout << "vsscommandprocessor::processQuery: authorize query with token = "
+         << token << " with request id " << request_id << endl;
 #endif
-                response = processAuthorize (channel, request_id, token ); 
-        } else if(action == "unsubscribe")  {
-		   uint32_t request_id = root["requestId"].as<int>();
-                   uint32_t subscribeID = root["subscriptionId"].as<int>();
+    response = processAuthorize(channel, request_id, token);
+  } else if (action == "unsubscribe") {
+    uint32_t request_id = root["requestId"].as<int>();
+    uint32_t subscribeID = root["subscriptionId"].as<int>();
 #ifdef DEBUG
-		   cout << "vsscommandprocessor::processQuery: unsubscribe query  for sub ID = " << subscribeID << " with request id " <<  request_id << endl;
+    cout
+        << "vsscommandprocessor::processQuery: unsubscribe query  for sub ID = "
+        << subscribeID << " with request id " << request_id << endl;
 #endif
-		   response = processUnsubscribe(request_id, subscribeID);
-       	} else {
-                string path = root["path"].as<string>();
-                uint32_t request_id = root["requestId"].as<int>();
-                
-                
-                
-                if (action == "get")  { 
+    response = processUnsubscribe(request_id, subscribeID);
+  } else {
+    string path = root["path"].as<string>();
+    uint32_t request_id = root["requestId"].as<int>();
+
+    if (action == "get") {
 #ifdef DEBUG
-		   cout << "vsscommandprocessor::processQuery: get query  for " << path << " with request id " <<  request_id << endl;
-#endif             
-                     
-                   response = processGet(channel,request_id, path);
+      cout << "vsscommandprocessor::processQuery: get query  for " << path
+           << " with request id " << request_id << endl;
+#endif
+
+      response = processGet(channel, request_id, path);
 #ifdef JSON_SIGNING_ON
-                   response = signer->sign(response);
+      response = signer->sign(response);
 #endif
-	        } else if(action == "set")  {
-                    
-		   json value = root["value"];
+    } else if (action == "set") {
+      json value = root["value"];
 #ifdef DEBUG
-		   cout << "vsscommandprocessor::processQuery: set query  for " << path << " with request id " <<  request_id  << " value " << pretty_print(value) << endl;
+      cout << "vsscommandprocessor::processQuery: set query  for " << path
+           << " with request id " << request_id << " value "
+           << pretty_print(value) << endl;
 #endif
-		   response = processSet(channel, request_id, path , value);	
-       	        } else if(action == "subscribe")  {
-                   
+      response = processSet(channel, request_id, path, value);
+    } else if (action == "subscribe") {
 #ifdef DEBUG
-		   cout << "vsscommandprocessor::processQuery: subscribe query  for " << path << " with request id " <<  request_id << endl;
+      cout << "vsscommandprocessor::processQuery: subscribe query  for " << path
+           << " with request id " << request_id << endl;
 #endif
-		   response = processSubscribe(channel, request_id, path , channel.getConnID());
-       	        }  else if (action == "getMetadata") {
+      response =
+          processSubscribe(channel, request_id, path, channel.getConnID());
+    } else if (action == "getMetadata") {
 #ifdef DEBUG
-		   cout << "vsscommandprocessor::processQuery: metadata query  for " << path << " with request id " <<  request_id << endl;
+      cout << "vsscommandprocessor::processQuery: metadata query  for " << path
+           << " with request id " << request_id << endl;
 #endif
-		   response = processGetMetaData(request_id,path);
-	        }  else {
-		   cout << "vsscommandprocessor::processQuery: Unknown action " << action << endl;
-	        }
-        }
+      response = processGetMetaData(request_id, path);
+    } else {
+      cout << "vsscommandprocessor::processQuery: Unknown action " << action
+           << endl;
+    }
+  }
 
-   return response;
-
+  return response;
 }
-
-

--- a/w3c-visserver-api/src/vssdatabase.cpp
+++ b/w3c-visserver-api/src/vssdatabase.cpp
@@ -11,600 +11,659 @@
  *      Robert Bosch GmbH - initial API and functionality
  * *****************************************************************************
  */
-#include <stdexcept>
-#include <limits> 
 #include "vssdatabase.hpp"
-#include "visconf.hpp"
+#include <limits>
 #include <regex>
+#include <stdexcept>
 #include "exception.hpp"
+#include "visconf.hpp"
 
 // Constructor
-vssdatabase::vssdatabase(class subscriptionhandler* subHandle, class accesschecker* accValidator) {
-   subHandler = subHandle;
-   accessValidator = accValidator;
-   rwMutex = new pthread_mutex_t();
-   pthread_mutex_init(rwMutex, NULL);
+vssdatabase::vssdatabase(class subscriptionhandler* subHandle,
+                         class accesschecker* accValidator) {
+  subHandler = subHandle;
+  accessValidator = accValidator;
+  rwMutex = new pthread_mutex_t();
+  pthread_mutex_init(rwMutex, NULL);
 }
 
 // Initializer
 void vssdatabase::initJsonTree() {
-    try {
+  try {
     string fileName = "vss_rel_1.0.json";
     std::ifstream is(fileName);
     is >> data_tree;
     meta_tree = data_tree;
 #ifdef DEBUG
-    cout << "vssdatabase::vssdatabase : VSS tree initialized using JSON file = " << fileName << endl;
+    cout << "vssdatabase::vssdatabase : VSS tree initialized using JSON file = "
+         << fileName << endl;
 #endif
     is.close();
-    } catch ( exception const &e) {
-       cout << "Exception occured while initializing database/ tree structure. Probably the init json file not found!" << e.what() << endl;
-       throw e; 
-    }	
+  } catch (exception const& e) {
+    cout << "Exception occured while initializing database/ tree structure. "
+            "Probably the init json file not found!"
+         << e.what() << endl;
+    throw e;
+  }
 }
 
 // Tokenizes path with '.' as separator.
 vector<string> getPathTokens(string path) {
-    vector<string> tokens;
-    char* path_char = (char *) path.c_str();
-    char* tok = strtok ( path_char , ".");
- 
-    while ( tok != NULL) {
-       tokens.push_back(string(tok));
-       tok = strtok( NULL ,".");
-    }
-    return tokens;
+  vector<string> tokens;
+  char* path_char = (char*)path.c_str();
+  char* tok = strtok(path_char, ".");
+
+  while (tok != NULL) {
+    tokens.push_back(string(tok));
+    tok = strtok(NULL, ".");
+  }
+  return tokens;
 }
 
-// Removes the internally used "children" tag and "$" tag and returns a client readable path.
+// Removes the internally used "children" tag and "$" tag and returns a client
+// readable path.
 // Eg: jsonpath = $['Signal']['children']['OBD']['children']['RPM']
-// The method returns Signal.OBD.RPM 
+// The method returns Signal.OBD.RPM
 string vssdatabase::getReadablePath(string jsonpath) {
   stringstream ss;
-  // regex to remove special characters from JSONPath and make it VSS compatible.
+  // regex to remove special characters from JSONPath and make it VSS
+  // compatible.
   std::regex bracket("[$\\[\\]']{2,4}");
-  std::copy( std::sregex_token_iterator(jsonpath.begin(), jsonpath.end(), bracket, -1),
-              std::sregex_token_iterator(),
-              std::ostream_iterator<std::string>(ss, "."));
+  std::copy(
+      std::sregex_token_iterator(jsonpath.begin(), jsonpath.end(), bracket, -1),
+      std::sregex_token_iterator(),
+      std::ostream_iterator<std::string>(ss, "."));
 
   ss.seekg(0, ios::end);
   int size = ss.tellg();
-  string readablePath = ss.str().substr(1, size-2);
-  regex e ("\\b(.children)([]*)");
-  readablePath = regex_replace (readablePath,e,"");
+  string readablePath = ss.str().substr(1, size - 2);
+  regex e("\\b(.children)([]*)");
+  readablePath = regex_replace(readablePath, e, "");
   return readablePath;
 }
 
-// Appends the internally used "children" tag to the path. And also formats the path in JSONPath querry format.
+// Appends the internally used "children" tag to the path. And also formats the
+// path in JSONPath querry format.
 // Eg: path = Signal.OBD.RPM
-// The method returns $['Signal']['children']['OBD']['children']['RPM'] and updates isBranch to false.
-string vssdatabase::getVSSSpecificPath (string path, bool &isBranch , json& tree) {
-    vector<string> tokens = getPathTokens(path);
-    int tokLength = tokens.size();
-    string format_path = "$";
-    for(int i=0; i < tokLength; i++) {
-      try {
-         if(tokens[i] == "*")
-            format_path = format_path + "[" + tokens[i] + "]";
-         else
-            format_path = format_path + "[\'" + tokens[i] + "\']";
-         json res = json_query(tree , format_path);
-         string type = "";
-         if((res.is_array() && res.size() > 0) && res[0].has_key("type")) {
-	   type = res[0]["type"].as<string>();
-	 } else if (res.has_key("type")) {
-           type = res["type"].as<string>();
-         }
-
-         if (type != "" && type == "branch") {
-             if( i <  (tokLength - 1)) {           
-                format_path = format_path + "[\'children\']";
-             }
-             isBranch = true;
-         } else if (type != "") {
-             isBranch = false;
-             break;
-         } else {
-             isBranch = false;
-             cout << "vssdatabase::getVSSSpecificPath : Path "<< format_path <<" is invalid or is an empty tag!" << endl;
-             return ""; 
-         }
-
-      } catch (exception& e) {
-         cout << "vssdatabase::getVSSSpecificPath :Exception "<< "\"" << e.what() << "\"" <<" occured while querying JSON. Check Path!"<<endl;
-         isBranch = false;
-         return ""; 
+// The method returns $['Signal']['children']['OBD']['children']['RPM'] and
+// updates isBranch to false.
+string vssdatabase::getVSSSpecificPath(string path, bool& isBranch,
+                                       json& tree) {
+  vector<string> tokens = getPathTokens(path);
+  int tokLength = tokens.size();
+  string format_path = "$";
+  for (int i = 0; i < tokLength; i++) {
+    try {
+      if (tokens[i] == "*")
+        format_path = format_path + "[" + tokens[i] + "]";
+      else
+        format_path = format_path + "[\'" + tokens[i] + "\']";
+      json res = json_query(tree, format_path);
+      string type = "";
+      if ((res.is_array() && res.size() > 0) && res[0].has_key("type")) {
+        type = res[0]["type"].as<string>();
+      } else if (res.has_key("type")) {
+        type = res["type"].as<string>();
       }
-   }
-   return format_path;
+
+      if (type != "" && type == "branch") {
+        if (i < (tokLength - 1)) {
+          format_path = format_path + "[\'children\']";
+        }
+        isBranch = true;
+      } else if (type != "") {
+        isBranch = false;
+        break;
+      } else {
+        isBranch = false;
+        cout << "vssdatabase::getVSSSpecificPath : Path " << format_path
+             << " is invalid or is an empty tag!" << endl;
+        return "";
+      }
+
+    } catch (exception& e) {
+      cout << "vssdatabase::getVSSSpecificPath :Exception "
+           << "\"" << e.what() << "\""
+           << " occured while querying JSON. Check Path!" << endl;
+      isBranch = false;
+      return "";
+    }
+  }
+  return format_path;
 }
 
-// Returns the absolute path but does not resolve wild card. Used only for metadata request.   
-string vssdatabase::getPathForMetadata(string path , bool &isBranch) {
-    string format_path = getVSSSpecificPath(path, isBranch , meta_tree); 
-    json pathRes =  json_query(meta_tree , format_path, result_type::path);
-    if(pathRes.size() > 0) {
-       string jPath = pathRes[0].as<string>();
-       return jPath;
-    } else {
-       return "";
-    }
-
+// Returns the absolute path but does not resolve wild card. Used only for
+// metadata request.
+string vssdatabase::getPathForMetadata(string path, bool& isBranch) {
+  string format_path = getVSSSpecificPath(path, isBranch, meta_tree);
+  json pathRes = json_query(meta_tree, format_path, result_type::path);
+  if (pathRes.size() > 0) {
+    string jPath = pathRes[0].as<string>();
+    return jPath;
+  } else {
+    return "";
+  }
 }
 
 // This method uses recursion.
-// Returns the path for get method. Resolves wild card and gives the absolute path.
+// Returns the path for get method. Resolves wild card and gives the absolute
+// path.
 // For eg : path = Signal.*.RPM
-// The method would return a list containing 1 signal path =  $['Signal']['children']['OBD']['children']['RPM']
-list<string> vssdatabase::getPathForGet(string path , bool &isBranch) {
+// The method would return a list containing 1 signal path =
+// $['Signal']['children']['OBD']['children']['RPM']
+list<string> vssdatabase::getPathForGet(string path, bool& isBranch) {
+  list<string> paths;
+  string format_path = getVSSSpecificPath(path, isBranch, data_tree);
+  json pathRes = json_query(data_tree, format_path, result_type::path);
 
-    list<string> paths;
-    string format_path = getVSSSpecificPath(path, isBranch, data_tree);
-    json pathRes =  json_query(data_tree , format_path, result_type::path);
-    
-    for ( int i=0 ; i < pathRes.size(); i++) {
-        string jPath = pathRes[i].as<string>();
-        json resArray = json_query(data_tree , jPath);
-        if( resArray.size() == 0) {
-            continue;
-        }
-        json result = resArray[0];
-        if(!result.has_key("id") && (result.has_key("type") && result["type"].as<string>() == "branch")) {
-             bool dummy = true;
-             paths.merge(getPathForGet( getReadablePath(jPath)+".*" , dummy));
-             continue;
-         } else {
-             paths.push_back(pathRes[i].as<string>());
-         }
+  for (int i = 0; i < pathRes.size(); i++) {
+    string jPath = pathRes[i].as<string>();
+    json resArray = json_query(data_tree, jPath);
+    if (resArray.size() == 0) {
+      continue;
     }
-    return paths;
+    json result = resArray[0];
+    if (!result.has_key("id") &&
+        (result.has_key("type") && result["type"].as<string>() == "branch")) {
+      bool dummy = true;
+      paths.merge(getPathForGet(getReadablePath(jPath) + ".*", dummy));
+      continue;
+    } else {
+      paths.push_back(pathRes[i].as<string>());
+    }
+  }
+  return paths;
 }
 
-// Tokenizes the signal path with '[' - ']' as separator for internal processing.
-// TODO- Regex could be used here?? 
+// Tokenizes the signal path with '[' - ']' as separator for internal
+// processing.
+// TODO- Regex could be used here??
 vector<string> getVSSTokens(string path) {
-
-    vector<string> tokens;
-    char* path_char = (char *) path.c_str();
-    char* tok = strtok ( path_char , "['");
-    int count = 1;
-    while ( tok != NULL) {
-       string tokString = string(tok); 
-       if( count % 2 == 0) {
-           tok = strtok( NULL ,"']");
-           tokens.push_back(tokString);
-       } else {
-           tok = strtok( NULL ,"['");
-       }
-       count ++;
+  vector<string> tokens;
+  char* path_char = (char*)path.c_str();
+  char* tok = strtok(path_char, "['");
+  int count = 1;
+  while (tok != NULL) {
+    string tokString = string(tok);
+    if (count % 2 == 0) {
+      tok = strtok(NULL, "']");
+      tokens.push_back(tokString);
+    } else {
+      tok = strtok(NULL, "['");
     }
+    count++;
+  }
 
-    return tokens;
+  return tokens;
 }
 
 // Returns the response JSON for metadata request.
 json vssdatabase::getMetaData(string path) {
+  string format_path = "$";
+  bool isBranch = false;
+  pthread_mutex_lock(rwMutex);
+  string jPath = getPathForMetadata(path, isBranch);
+  pthread_mutex_unlock(rwMutex);
 
-	string format_path = "$";
-        bool isBranch = false;
-        pthread_mutex_lock (rwMutex);
-        string jPath = getPathForMetadata(path, isBranch);
-        pthread_mutex_unlock (rwMutex);
-
-        if(jPath == "") {
-            return NULL;
-        }
+  if (jPath == "") {
+    return NULL;
+  }
 #ifdef DEBUG
-        cout << "vssdatabase::getMetaData: VSS specific path =" << jPath << endl;
+  cout << "vssdatabase::getMetaData: VSS specific path =" << jPath << endl;
 #endif
 
-        vector<string> tokens = getVSSTokens(jPath);
-	int tokLength = tokens.size();
+  vector<string> tokens = getVSSTokens(jPath);
+  int tokLength = tokens.size();
 
-	json parentArray[16];
-        string parentName[16];
+  json parentArray[16];
+  string parentName[16];
 
-        int parentCount = 0;
-        json resJson;
-	for(int i=0; i< tokLength; i++) {
-	    
-	   format_path = format_path + "."+ tokens[i] ;
-           if( (i < tokLength-1) && (tokens[i] == "children")) {
-               continue;
-           }
-           pthread_mutex_lock (rwMutex);
-	   json resArray = json_query(meta_tree , format_path);
-           pthread_mutex_unlock (rwMutex);
-	  	  
-	   if(resArray.is_array() && resArray.size() == 1) {
-              resJson = resArray[0];
-                 if(resJson.has_key("description")) {
-		    resJson.insert_or_assign("description", resJson["description"].as<string>());
-		 }
- 
-                 if(resJson.has_key("type")) {
-                    string type = resJson["type"].as<string>();
-		    resJson.insert_or_assign("type", type);
-                 }
-	   } else {
-                 // handle exception.
-                 cout << "vssdatabase::getMetaData : More than 1 Branch/ value found! Path requested needs to be more refined" << endl;
-                 return NULL;
-           }
+  int parentCount = 0;
+  json resJson;
+  for (int i = 0; i < tokLength; i++) {
+    format_path = format_path + "." + tokens[i];
+    if ((i < tokLength - 1) && (tokens[i] == "children")) {
+      continue;
+    }
+    pthread_mutex_lock(rwMutex);
+    json resArray = json_query(meta_tree, format_path);
+    pthread_mutex_unlock(rwMutex);
 
-           // last element is the requested signal.
-	   if ((i == tokLength-1) && (tokens[i] != "children")) {
-	      json value;
-	      value.insert_or_assign(tokens[i],resJson);
-	      resJson = value;
-           }
+    if (resArray.is_array() && resArray.size() == 1) {
+      resJson = resArray[0];
+      if (resJson.has_key("description")) {
+        resJson.insert_or_assign("description",
+                                 resJson["description"].as<string>());
+      }
 
-	   parentArray[parentCount] = resJson;
-           parentName[parentCount] = tokens[i];
-           parentCount++;
-	}
+      if (resJson.has_key("type")) {
+        string type = resJson["type"].as<string>();
+        resJson.insert_or_assign("type", type);
+      }
+    } else {
+      // handle exception.
+      cout << "vssdatabase::getMetaData : More than 1 Branch/ value found! "
+              "Path requested needs to be more refined"
+           << endl;
+      return NULL;
+    }
 
-	json result = resJson;
-        
+    // last element is the requested signal.
+    if ((i == tokLength - 1) && (tokens[i] != "children")) {
+      json value;
+      value.insert_or_assign(tokens[i], resJson);
+      resJson = value;
+    }
 
-	for(int i = parentCount - 2; i >= 0 ; i--) {
-	     json element =  parentArray[i];
-	     element.insert_or_assign("children", result);
-	     json parent;
-	     parent.insert_or_assign(parentName[i] , element);
-	     result = parent;
-	 }
+    parentArray[parentCount] = resJson;
+    parentName[parentCount] = tokens[i];
+    parentCount++;
+  }
 
-       return result;
+  json result = resJson;
+
+  for (int i = parentCount - 2; i >= 0; i--) {
+    json element = parentArray[i];
+    element.insert_or_assign("children", result);
+    json parent;
+    parent.insert_or_assign(parentName[i], element);
+    result = parent;
+  }
+
+  return result;
 }
 
-// returns the absolute path based on the base path and the path in the values JSON.
+// returns the absolute path based on the base path and the path in the values
+// JSON.
 // eg : path = Signal.*
 //      values = {"OBD.RPM" : 23, "OBD.Speed" : 10}
-// The function would return = {{"path" : "$.Signal.children.OBD.children.RPM", "value" : 23}, {"path" : "$.Signal.children.OBD.children.Speed", "value" : 10}}
+// The function would return = {{"path" : "$.Signal.children.OBD.children.RPM",
+// "value" : 23}, {"path" : "$.Signal.children.OBD.children.Speed", "value" :
+// 10}}
 json vssdatabase::getPathForSet(string path, json values) {
-
   json setValues;
-  if(values.is_array()) {
-     std::size_t found = path.find("*");
-     if (found==std::string::npos) {
-         path = path + ".";
-         found = path.length();
-     }
-     setValues = json::make_array(values.size());
-     for( int i=0 ;i < values.size() ; i++) {
-         json value = values[i];
-         string readablePath = path;
-         string replaceString; 
-         auto iter = value.object_range();
+  if (values.is_array()) {
+    std::size_t found = path.find("*");
+    if (found == std::string::npos) {
+      path = path + ".";
+      found = path.length();
+    }
+    setValues = json::make_array(values.size());
+    for (int i = 0; i < values.size(); i++) {
+      json value = values[i];
+      string readablePath = path;
+      string replaceString;
+      auto iter = value.object_range();
 
-         int size = std::distance(iter.begin(),iter.end());
+      int size = std::distance(iter.begin(), iter.end());
 
-         if( size == 1) {
-              for (const auto& member : iter)
-              {
-                  replaceString = string(member.key());
-              }
-         } else {
-             stringstream msg;
-             msg << "More than 1 signal found while setting for path = " << path << " with values " <<   pretty_print(values);
-             throw genException(msg.str());
-         }
-         readablePath.replace(found,readablePath.length(), replaceString); 
-         json pathValue;
-         bool isBranch = false;
-         string absolutePath = getVSSSpecificPath(readablePath , isBranch , data_tree);
-         if( isBranch ) {
-             stringstream msg;
-             msg<< "Path = " << path << " with values " <<  pretty_print(values) << " points to a branch. Needs to point to a signal";
-             throw genException (msg.str());
-         }
-         
-         pathValue["path"] = absolutePath;
-         pathValue["value"] = value[replaceString];
-         setValues[i] = pathValue;
-     }
+      if (size == 1) {
+        for (const auto& member : iter) {
+          replaceString = string(member.key());
+        }
+      } else {
+        stringstream msg;
+        msg << "More than 1 signal found while setting for path = " << path
+            << " with values " << pretty_print(values);
+        throw genException(msg.str());
+      }
+      readablePath.replace(found, readablePath.length(), replaceString);
+      json pathValue;
+      bool isBranch = false;
+      string absolutePath =
+          getVSSSpecificPath(readablePath, isBranch, data_tree);
+      if (isBranch) {
+        stringstream msg;
+        msg << "Path = " << path << " with values " << pretty_print(values)
+            << " points to a branch. Needs to point to a signal";
+        throw genException(msg.str());
+      }
+
+      pathValue["path"] = absolutePath;
+      pathValue["value"] = value[replaceString];
+      setValues[i] = pathValue;
+    }
   } else {
-       setValues = json::make_array(1);
-       json pathValue;
-       bool isBranch = false;
-       string absolutePath = getVSSSpecificPath(path , isBranch, data_tree);
-       if( isBranch ) {
-           stringstream msg;
-           msg << "Path = " << path << " with values " <<   pretty_print(values) << " points to a branch. Needs to point to a signal";
-           throw genException (msg.str());
-       } 
-       pathValue["path"] = absolutePath;
-       pathValue["value"] = values;
-       setValues[0] = pathValue;
+    setValues = json::make_array(1);
+    json pathValue;
+    bool isBranch = false;
+    string absolutePath = getVSSSpecificPath(path, isBranch, data_tree);
+    if (isBranch) {
+      stringstream msg;
+      msg << "Path = " << path << " with values " << pretty_print(values)
+          << " points to a branch. Needs to point to a signal";
+      throw genException(msg.str());
+    }
+    pathValue["path"] = absolutePath;
+    pathValue["value"] = values;
+    setValues[0] = pathValue;
   }
   return setValues;
 }
 
 // Check the value type and if the value is within the range
-void checkTypeAndBound (string value_type, json val) {
-    bool typeValid = false;
-     
-    if(value_type == "UInt8") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<uint8_t>::max()) && (longDoubleVal >= numeric_limits<uint8_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());  
-       }
-	         
-    }else if (value_type == "UInt16") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<uint16_t>::max()) && (longDoubleVal >= numeric_limits<uint16_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());
-       } 
-	         
-    }else if (value_type == "UInt32") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<uint32_t>::max()) && (longDoubleVal >= numeric_limits<uint32_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << " for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());
-       } 
-	         
-    }else if (value_type == "Int8") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<int8_t>::max()) && (longDoubleVal >= numeric_limits<int8_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());  
-       }         
-    }else if (value_type == "Int16") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<int16_t>::max()) && (longDoubleVal >= numeric_limits<int16_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());  
-       } 
-	         
-    }else if (value_type == "Int32") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       if(!((longDoubleVal <= numeric_limits<int32_t>::max()) && (longDoubleVal >= numeric_limits<int32_t>::min()))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<float>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<float>() << " is out of bound";
-          throw outOfBoundException (msg.str());   
-       }        
-    }else if (value_type == "Float") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       float max = numeric_limits<float>::max();
-       float min = numeric_limits<float>::min();
-       if(!((longDoubleVal <= max) && (longDoubleVal >= min) || (longDoubleVal >= ( max * -1)) && (longDoubleVal <= (min * -1)))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<double>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<double>() << " is out of bound";
-          throw outOfBoundException (msg.str());   
-       }        
-    }else if (value_type == "Double") {
-       typeValid = true;
-       long double longDoubleVal = val.as<long double>();
-       double max = numeric_limits<double>::max();
-       double min = numeric_limits<double>::min();
-       if(!((longDoubleVal <= max) && (longDoubleVal >= min) || (longDoubleVal >= (max * -1)) && (longDoubleVal <= (min * -1)))) {
-          cout<< "vssdatabase::setSignal: The value passed " << val.as<long double>() << "for type "<< value_type <<" is out of bound."<< endl;
-          std::stringstream msg;
-          msg << "The type " << value_type << " with value " << val.as<long double>() << " is out of bound";
-          throw outOfBoundException (msg.str());   
-       }
-	         
-    }else if (value_type == "Boolean"){
-       typeValid = true;         
-    }else if (value_type == "String") {
-       typeValid = true;
+void checkTypeAndBound(string value_type, json val) {
+  bool typeValid = false;
+
+  if (value_type == "UInt8") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<uint8_t>::max()) &&
+          (longDoubleVal >= numeric_limits<uint8_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
     }
 
-    if (!typeValid) {
-        cout<< "vssdatabase::setSignal: The  type "<< value_type <<" is either not supported "<< endl;
-        string msg = "The type " + value_type +" is not supported ";
-        throw genException (msg);
-    } 
+  } else if (value_type == "UInt16") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<uint16_t>::max()) &&
+          (longDoubleVal >= numeric_limits<uint16_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+
+  } else if (value_type == "UInt32") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<uint32_t>::max()) &&
+          (longDoubleVal >= numeric_limits<uint32_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << " for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+
+  } else if (value_type == "Int8") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<int8_t>::max()) &&
+          (longDoubleVal >= numeric_limits<int8_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+  } else if (value_type == "Int16") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<int16_t>::max()) &&
+          (longDoubleVal >= numeric_limits<int16_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+
+  } else if (value_type == "Int32") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    if (!((longDoubleVal <= numeric_limits<int32_t>::max()) &&
+          (longDoubleVal >= numeric_limits<int32_t>::min()))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<float>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<float>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+  } else if (value_type == "Float") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    float max = numeric_limits<float>::max();
+    float min = numeric_limits<float>::min();
+    if (!((longDoubleVal <= max) && (longDoubleVal >= min) ||
+          (longDoubleVal >= (max * -1)) && (longDoubleVal <= (min * -1)))) {
+      cout << "vssdatabase::setSignal: The value passed " << val.as<double>()
+           << "for type " << value_type << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value " << val.as<double>()
+          << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+  } else if (value_type == "Double") {
+    typeValid = true;
+    long double longDoubleVal = val.as<long double>();
+    double max = numeric_limits<double>::max();
+    double min = numeric_limits<double>::min();
+    if (!((longDoubleVal <= max) && (longDoubleVal >= min) ||
+          (longDoubleVal >= (max * -1)) && (longDoubleVal <= (min * -1)))) {
+      cout << "vssdatabase::setSignal: The value passed "
+           << val.as<long double>() << "for type " << value_type
+           << " is out of bound." << endl;
+      std::stringstream msg;
+      msg << "The type " << value_type << " with value "
+          << val.as<long double>() << " is out of bound";
+      throw outOfBoundException(msg.str());
+    }
+
+  } else if (value_type == "Boolean") {
+    typeValid = true;
+  } else if (value_type == "String") {
+    typeValid = true;
+  }
+
+  if (!typeValid) {
+    cout << "vssdatabase::setSignal: The  type " << value_type
+         << " is either not supported " << endl;
+    string msg = "The type " + value_type + " is not supported ";
+    throw genException(msg);
+  }
 }
 
-
 // Method for setting values to signals.
-void vssdatabase::setSignal(class wschannel& channel,string path, json valueJson) {
+void vssdatabase::setSignal(class wschannel& channel, string path,
+                            json valueJson) {
+  if (path == "") {
+    string msg = "Path is empty while setting";
+    throw genException(msg);
+  }
+  pthread_mutex_lock(rwMutex);
+  json setValues = getPathForSet(path, valueJson);
+  pthread_mutex_unlock(rwMutex);
 
-    if(path == "") {
-         string msg = "Path is empty while setting";
-         throw genException (msg);
-    } 
-    pthread_mutex_lock (rwMutex);
-    json setValues = getPathForSet(path, valueJson);
-    pthread_mutex_unlock (rwMutex);
-    
-    if(setValues.is_array()) {
-       // check if all the paths have write access.
-       bool haveAccess = accessValidator->checkPathWriteAccess(channel, setValues);
-       if(!haveAccess) {
-         stringstream msg;
-         msg << "Path(s) in set request do not have write access or is invalid";
-         throw noPermissionException (msg.str());
-       } 
-
-       for( int i=0 ; i< setValues.size() ; i++) {
-          json item = setValues[i];
-          string jPath = item["path"].as<string>();
-#ifdef DEBUG
-          cout << "vssdatabase::setSignal: path found = "<< jPath << endl;
-          cout << "value to set asstring = " << item["value"].as<string>() <<endl;
-#endif
-          pthread_mutex_lock (rwMutex);
-          json resArray = json_query(data_tree , jPath);
-          pthread_mutex_unlock (rwMutex);
-          if(resArray.is_array() && resArray.size() == 1) {
-             json resJson = resArray[0];
-             if(resJson.has_key("type")) {
-                string value_type = resJson["type"].as<string>();
-                json val = item["value"];
-	        checkTypeAndBound(value_type, val);
-              
-                resJson.insert_or_assign("value", val);
-
-                pthread_mutex_lock (rwMutex);
-                json_replace(data_tree , jPath, resJson);
-                pthread_mutex_unlock (rwMutex);
-#ifdef DEBUG
-                cout << "vssdatabase::setSignal: new value set at path " << jPath << endl;
-#endif
-
-                int signalID = resJson["id"].as<int>();
-               
-                json value = resJson["value"];
-                subHandler->update(signalID, value);
-
-             } else {
-                stringstream msg;
-                msg << "Type key not found for " << jPath;
-                throw genException (msg.str());
-             }
-        
-          } else if (resArray.is_array()) { 
-               cout <<"vssdatabase::setSignal : Path " << jPath <<" has "<<resArray.size()<<" signals, the path needs refinement"<<endl;
-               stringstream msg;
-               msg << "Path " << jPath <<" has " << resArray.size() << " signals, the path needs refinement";
-               throw genException (msg.str());
-          }           
-       } 
-    } else {
-        string msg = "Exception occured while setting data for " + path;
-        throw genException (msg);
+  if (setValues.is_array()) {
+    // check if all the paths have write access.
+    bool haveAccess = accessValidator->checkPathWriteAccess(channel, setValues);
+    if (!haveAccess) {
+      stringstream msg;
+      msg << "Path(s) in set request do not have write access or is invalid";
+      throw noPermissionException(msg.str());
     }
+
+    for (int i = 0; i < setValues.size(); i++) {
+      json item = setValues[i];
+      string jPath = item["path"].as<string>();
+#ifdef DEBUG
+      cout << "vssdatabase::setSignal: path found = " << jPath << endl;
+      cout << "value to set asstring = " << item["value"].as<string>() << endl;
+#endif
+      pthread_mutex_lock(rwMutex);
+      json resArray = json_query(data_tree, jPath);
+      pthread_mutex_unlock(rwMutex);
+      if (resArray.is_array() && resArray.size() == 1) {
+        json resJson = resArray[0];
+        if (resJson.has_key("type")) {
+          string value_type = resJson["type"].as<string>();
+          json val = item["value"];
+          checkTypeAndBound(value_type, val);
+
+          resJson.insert_or_assign("value", val);
+
+          pthread_mutex_lock(rwMutex);
+          json_replace(data_tree, jPath, resJson);
+          pthread_mutex_unlock(rwMutex);
+#ifdef DEBUG
+          cout << "vssdatabase::setSignal: new value set at path " << jPath
+               << endl;
+#endif
+
+          int signalID = resJson["id"].as<int>();
+
+          json value = resJson["value"];
+          subHandler->update(signalID, value);
+
+        } else {
+          stringstream msg;
+          msg << "Type key not found for " << jPath;
+          throw genException(msg.str());
+        }
+
+      } else if (resArray.is_array()) {
+        cout << "vssdatabase::setSignal : Path " << jPath << " has "
+             << resArray.size() << " signals, the path needs refinement"
+             << endl;
+        stringstream msg;
+        msg << "Path " << jPath << " has " << resArray.size()
+            << " signals, the path needs refinement";
+        throw genException(msg.str());
+      }
+    }
+  } else {
+    string msg = "Exception occured while setting data for " + path;
+    throw genException(msg);
+  }
 }
 
 // Utility method for setting values to JSON.
-void setJsonValue(json& dest , json& source , string key) {
-
-  if(!source.has_key("type")) {
-     cout << "vssdatabase::setJsonValue : could not set value! type is not present in source json!"<< endl;
-     string msg = "Unknown type for signal found at " + key;
-     throw genException (msg); 
+void setJsonValue(json& dest, json& source, string key) {
+  if (!source.has_key("type")) {
+    cout << "vssdatabase::setJsonValue : could not set value! type is not "
+            "present in source json!"
+         << endl;
+    string msg = "Unknown type for signal found at " + key;
+    throw genException(msg);
   }
   dest[key] = source["value"];
 }
 
 // Returns response JSON for get request.
-json vssdatabase::getSignal(class wschannel& channel,string path) {
-    
-    bool isBranch = false;
-    
-    pthread_mutex_lock (rwMutex);
-    list<string> jPaths = getPathForGet(path, isBranch);
-    pthread_mutex_unlock (rwMutex);
-    int pathsFound = jPaths.size();
-    if(pathsFound == 0) {
-        json answer;
-        return answer;
-    } 
+json vssdatabase::getSignal(class wschannel& channel, string path) {
+  bool isBranch = false;
+
+  pthread_mutex_lock(rwMutex);
+  list<string> jPaths = getPathForGet(path, isBranch);
+  pthread_mutex_unlock(rwMutex);
+  int pathsFound = jPaths.size();
+  if (pathsFound == 0) {
+    json answer;
+    return answer;
+  }
 #ifdef DEBUG
-    cout << "vssdatabase::getSignal: "<< pathsFound << " signals found under path = "<< "\"" << path << "\"" << endl;
+  cout << "vssdatabase::getSignal: " << pathsFound
+       << " signals found under path = "
+       << "\"" << path << "\"" << endl;
 #endif
-    if(isBranch) {
-       json answer;    
+  if (isBranch) {
+    json answer;
 #ifdef DEBUG
-       cout << " vssdatabase::getSignal :"<< "\"" << path << "\"" << " is a Branch." <<endl;
+    cout << " vssdatabase::getSignal :"
+         << "\"" << path << "\""
+         << " is a Branch." << endl;
 #endif
-       if (pathsFound == 0) {
-          throw noPathFoundonTree(path);
-       } else {
-          json value;
-          
-          for( int i=0 ; i< pathsFound ; i++) {
-              string jPath = jPaths.back();
-              // check Read access here.
-              if (!accessValidator->checkReadAccess(channel , jPath)) {
-                 // Allow the permitted signals to return. If exception is enable here, then say only "Signal.OBD.RPM" is permitted and get request is made for a branch like "Signal.OBD" then 
-                 // an error would be returned. By disabling the exception the value for Signal.OBD.RPM (only) will be returned.
-                 /*stringstream msg;
-                 msg << "No read access to  " << getReadablePath(jPath);
-                 throw genException (msg.str());*/
-                 jPaths.pop_back();
-                 continue;
-              }
-              pthread_mutex_lock (rwMutex);
-              json resArray = json_query(data_tree , jPath);
-              pthread_mutex_unlock (rwMutex);
-              jPaths.pop_back();
-              json result = resArray[0];
-              if(result.has_key("value")) {
-                  setJsonValue(value , result, getReadablePath(jPath));  
-              } else {
-                  value[getReadablePath(jPath)] = "---";
-              }
-          }
-          answer["value"] = value;
-       } 
-       return answer;   
-    } else if (pathsFound == 1) {
-      string jPath = jPaths.back();
-      // check Read access here.
-      if (!accessValidator->checkReadAccess(channel , jPath)) {
-         stringstream msg;
-         msg << "No read access to  " << getReadablePath(jPath);
-         throw noPermissionException (msg.str());
-      }
-      pthread_mutex_lock (rwMutex);
-      json resArray = json_query(data_tree , jPath);
-      pthread_mutex_unlock (rwMutex);
-      json answer;
-      answer["path"] = getReadablePath(jPath); 
-      json result = resArray[0];
-      if(result.has_key("value")) {
-         setJsonValue(answer , result, "value");
-         return answer;
-      } else {
-         answer["value"] = "---";
-         return answer;
-      }
-       
-    } else if (pathsFound > 1) {
-       json answer;
-       json valueArray = json::array();
-       
-        for (int i=0 ; i< pathsFound; i++) {
-              json value;
-              string jPath = jPaths.back();
-              // Check access here.
-              if (!accessValidator->checkReadAccess(channel , jPath)) {
-                 // Allow the permitted signals to return. If exception is enable here, then say only "Signal.OBD.RPM" is permitted and get request is made using wildcard like "Signal.OBD.*" then 
-                 // an error would be returned. By disabling the exception the value for Signal.OBD.RPM (only) will be returned.
-                 /*stringstream msg;
-                 msg << "No read access to  " << getReadablePath(jPath);
-                 throw genException (msg.str());*/
-                 jPaths.pop_back();
-                 continue;
-              }
-              pthread_mutex_lock (rwMutex);
-              json resArray = json_query(data_tree , jPath);
-              pthread_mutex_unlock (rwMutex);
-              jPaths.pop_back();
-              json result = resArray[0];
-              if(result.has_key("value")) {
-                  setJsonValue(value , result, getReadablePath(jPath));   
-              } else {
-                  value[getReadablePath(jPath)] = "---";
-              }
-              valueArray.insert(valueArray.array_range().end(), value);
+    if (pathsFound == 0) {
+      throw noPathFoundonTree(path);
+    } else {
+      json value;
+
+      for (int i = 0; i < pathsFound; i++) {
+        string jPath = jPaths.back();
+        // check Read access here.
+        if (!accessValidator->checkReadAccess(channel, jPath)) {
+          // Allow the permitted signals to return. If exception is enable here,
+          // then say only "Signal.OBD.RPM" is permitted and get request is made
+          // for a branch like "Signal.OBD" then
+          // an error would be returned. By disabling the exception the value
+          // for Signal.OBD.RPM (only) will be returned.
+          /*stringstream msg;
+          msg << "No read access to  " << getReadablePath(jPath);
+          throw genException (msg.str());*/
+          jPaths.pop_back();
+          continue;
         }
-        answer["value"] = valueArray;
-        return answer;
+        pthread_mutex_lock(rwMutex);
+        json resArray = json_query(data_tree, jPath);
+        pthread_mutex_unlock(rwMutex);
+        jPaths.pop_back();
+        json result = resArray[0];
+        if (result.has_key("value")) {
+          setJsonValue(value, result, getReadablePath(jPath));
+        } else {
+          value[getReadablePath(jPath)] = "---";
+        }
+      }
+      answer["value"] = value;
     }
+    return answer;
+  } else if (pathsFound == 1) {
+    string jPath = jPaths.back();
+    // check Read access here.
+    if (!accessValidator->checkReadAccess(channel, jPath)) {
+      stringstream msg;
+      msg << "No read access to  " << getReadablePath(jPath);
+      throw noPermissionException(msg.str());
+    }
+    pthread_mutex_lock(rwMutex);
+    json resArray = json_query(data_tree, jPath);
+    pthread_mutex_unlock(rwMutex);
+    json answer;
+    answer["path"] = getReadablePath(jPath);
+    json result = resArray[0];
+    if (result.has_key("value")) {
+      setJsonValue(answer, result, "value");
+      return answer;
+    } else {
+      answer["value"] = "---";
+      return answer;
+    }
+
+  } else if (pathsFound > 1) {
+    json answer;
+    json valueArray = json::array();
+
+    for (int i = 0; i < pathsFound; i++) {
+      json value;
+      string jPath = jPaths.back();
+      // Check access here.
+      if (!accessValidator->checkReadAccess(channel, jPath)) {
+        // Allow the permitted signals to return. If exception is enable here,
+        // then say only "Signal.OBD.RPM" is permitted and get request is made
+        // using wildcard like "Signal.OBD.*" then
+        // an error would be returned. By disabling the exception the value for
+        // Signal.OBD.RPM (only) will be returned.
+        /*stringstream msg;
+        msg << "No read access to  " << getReadablePath(jPath);
+        throw genException (msg.str());*/
+        jPaths.pop_back();
+        continue;
+      }
+      pthread_mutex_lock(rwMutex);
+      json resArray = json_query(data_tree, jPath);
+      pthread_mutex_unlock(rwMutex);
+      jPaths.pop_back();
+      json result = resArray[0];
+      if (result.has_key("value")) {
+        setJsonValue(value, result, getReadablePath(jPath));
+      } else {
+        value[getReadablePath(jPath)] = "---";
+      }
+      valueArray.insert(valueArray.array_range().end(), value);
+    }
+    answer["value"] = valueArray;
+    return answer;
+  }
 }

--- a/w3c-visserver-api/src/wsserver.cpp
+++ b/w3c-visserver-api/src/wsserver.cpp
@@ -12,193 +12,197 @@
  * *****************************************************************************
  */
 #include "wsserver.hpp"
- 
 
 uint16_t connections[MAX_CLIENTS + 1] = {0};
-wsserver* wserver;
+wsserver *wserver;
 
 uint32_t generateConnID() {
- uint32_t  retValueValue = 0;
-   for(int i=1 ; i<(MAX_CLIENTS + 1) ; i++) {
-     if(connections[i] == 0) {
-         connections[i]= i;
-         retValueValue = CLIENT_MASK * (i);
-         return retValueValue;
-     } 
+  uint32_t retValueValue = 0;
+  for (int i = 1; i < (MAX_CLIENTS + 1); i++) {
+    if (connections[i] == 0) {
+      connections[i] = i;
+      retValueValue = CLIENT_MASK * (i);
+      return retValueValue;
+    }
   }
-    return retValueValue;
+  return retValueValue;
 }
-
-
 
 wsserver::wsserver(int port, bool secure) {
   isSecure = secure;
 
-  if(isSecure) {
-     secureServer = new WssServer("Server.pem", "Server.key");
-     secureServer->config.port = port;
+  if (isSecure) {
+    secureServer = new WssServer("Server.pem", "Server.key");
+    secureServer->config.port = port;
   } else {
-     insecureServer = new WsServer();
-     insecureServer->config.port = port;
+    insecureServer = new WsServer();
+    insecureServer->config.port = port;
   }
-  
-  tokenValidator =  new authenticator("appstacle", "RS256");
+
+  tokenValidator = new authenticator("appstacle", "RS256");
   accessCheck = new accesschecker(tokenValidator);
   subHandler = new subscriptionhandler(this, tokenValidator, accessCheck);
-  database = new vssdatabase(subHandler , accessCheck);
+  database = new vssdatabase(subHandler, accessCheck);
   cmdProcessor = new vsscommandprocessor(database, tokenValidator, subHandler);
   wserver = this;
 }
 
 wsserver::~wsserver() {
-   // destructor
-  
+  // destructor
 }
 
+static void onMessage(shared_ptr<WssServer::Connection> connection,
+                      string message) {
+#ifdef DEBUG
+  cout << "main::onMessage: Message received: \"" << message << "\" from "
+       << connection->remote_endpoint_address() << endl;
+#endif
+  string response =
+      wserver->cmdProcessor->processQuery(message, connection->channel);
 
-static void onMessage (shared_ptr<WssServer::Connection> connection, string message) {
-  #ifdef DEBUG
-      cout << "main::onMessage: Message received: \"" << message << "\" from " << connection->remote_endpoint_address() << endl;
-  #endif
-      string response = wserver->cmdProcessor->processQuery(message, connection->channel);
-     
-      auto send_stream = make_shared<WssServer::SendStream>();
-      *send_stream << response;
-      connection->send(send_stream);
+  auto send_stream = make_shared<WssServer::SendStream>();
+  *send_stream << response;
+  connection->send(send_stream);
 }
 
+static void onMessage(shared_ptr<WsServer::Connection> connection,
+                      string message) {
+#ifdef DEBUG
+  cout << "main::onMessage: Message received: \"" << message << "\" from "
+       << connection->remote_endpoint_address() << endl;
+#endif
+  string response =
+      wserver->cmdProcessor->processQuery(message, connection->channel);
 
-static void onMessage (shared_ptr<WsServer::Connection> connection, string message) {
-  #ifdef DEBUG
-      cout << "main::onMessage: Message received: \"" << message << "\" from " << connection->remote_endpoint_address() << endl;
-  #endif
-      string response = wserver->cmdProcessor->processQuery(message, connection->channel);
-     
-      auto send_stream = make_shared<WsServer::SendStream>();
-      *send_stream << response;
-      connection->send(send_stream);
+  auto send_stream = make_shared<WsServer::SendStream>();
+  *send_stream << response;
+  connection->send(send_stream);
 }
-
 
 void wsserver::startServer(string endpointName) {
-   if( isSecure ) {        
+  if (isSecure) {
     auto &vssEndpoint = secureServer->endpoint["^/vss/?$"];
 
-   vssEndpoint.on_message = [](shared_ptr<WssServer::Connection> connection, shared_ptr<WssServer::Message> message) {
+    vssEndpoint.on_message = [](shared_ptr<WssServer::Connection> connection,
+                                shared_ptr<WssServer::Message> message) {
       auto message_str = message->string();
-      onMessage(connection , message_str);
+      onMessage(connection, message_str);
 
     };
 
-   vssEndpoint.on_open = [](shared_ptr<WssServer::Connection> connection) {
-       connection->channel.setConnID(generateConnID());
-       cout << "wsserver: Opened connection " << connection->remote_endpoint_address()<< "conn ID " << connection->channel.getConnID() << endl;
+    vssEndpoint.on_open = [](shared_ptr<WssServer::Connection> connection) {
+      connection->channel.setConnID(generateConnID());
+      cout << "wsserver: Opened connection "
+           << connection->remote_endpoint_address() << "conn ID "
+           << connection->channel.getConnID() << endl;
     };
 
-   // See RFC 6455 7.4.1. for status codes
-   vssEndpoint.on_close = [](shared_ptr<WssServer::Connection> connection, int status, const string & /*reason*/) {
-        uint32_t clientID = connection->channel.getConnID()/CLIENT_MASK;
-        connections[clientID] = 0;
-        //removeAllSubscriptions(clientID);
-        cout << "wsserver: Closed connection " << connection->remote_endpoint_address() << " with status code " << status << endl;
+    // See RFC 6455 7.4.1. for status codes
+    vssEndpoint.on_close = [](shared_ptr<WssServer::Connection> connection,
+                              int status, const string & /*reason*/) {
+      uint32_t clientID = connection->channel.getConnID() / CLIENT_MASK;
+      connections[clientID] = 0;
+      // removeAllSubscriptions(clientID);
+      cout << "wsserver: Closed connection "
+           << connection->remote_endpoint_address() << " with status code "
+           << status << endl;
     };
 
-   // See http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html, Error Codes for error code meanings
-   vssEndpoint.on_error = [](shared_ptr<WssServer::Connection> connection, const SimpleWeb::error_code &ec) {
-        uint32_t clientID = connection->channel.getConnID()/CLIENT_MASK;
-        connections[clientID] = 0;
-        //removeAllSubscriptions(clientID);
-        cout << "wsserver: Error in connection " << connection->remote_endpoint_address()<<" with con ID "<< connection->channel.getConnID()<< ". "
-         << "Error: " << ec << ", error message: " << ec.message() << endl;
+    // See
+    // http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html,
+    // Error Codes for error code meanings
+    vssEndpoint.on_error = [](shared_ptr<WssServer::Connection> connection,
+                              const SimpleWeb::error_code &ec) {
+      uint32_t clientID = connection->channel.getConnID() / CLIENT_MASK;
+      connections[clientID] = 0;
+      // removeAllSubscriptions(clientID);
+      cout << "wsserver: Error in connection "
+           << connection->remote_endpoint_address() << " with con ID "
+           << connection->channel.getConnID() << ". "
+           << "Error: " << ec << ", error message: " << ec.message() << endl;
     };
 
-      cout << "started Secure WS server" << endl; 
-      secureServer->start();
-   } else {
-       
-   auto &vssEndpoint = insecureServer->endpoint["^/vss/?$"];
+    cout << "started Secure WS server" << endl;
+    secureServer->start();
+  } else {
+    auto &vssEndpoint = insecureServer->endpoint["^/vss/?$"];
 
-   vssEndpoint.on_message = [](shared_ptr<WsServer::Connection> connection, shared_ptr<WsServer::Message> message) {
+    vssEndpoint.on_message = [](shared_ptr<WsServer::Connection> connection,
+                                shared_ptr<WsServer::Message> message) {
       auto message_str = message->string();
-      onMessage(connection , message_str);
+      onMessage(connection, message_str);
 
     };
 
-   vssEndpoint.on_open = [](shared_ptr<WsServer::Connection> connection) {
-       connection->channel.setConnID(generateConnID());
+    vssEndpoint.on_open = [](shared_ptr<WsServer::Connection> connection) {
+      connection->channel.setConnID(generateConnID());
 #ifdef DEBUG
-       cout << "wsserver: Opened connection " << connection->remote_endpoint_address()<< "conn ID " << connection->channel.getConnID() << endl;
+      cout << "wsserver: Opened connection "
+           << connection->remote_endpoint_address() << "conn ID "
+           << connection->channel.getConnID() << endl;
 #endif
     };
 
-   // See RFC 6455 7.4.1. for status codes
-   vssEndpoint.on_close = [](shared_ptr<WsServer::Connection> connection, int status, const string & /*reason*/) {
-        uint32_t clientID = connection->channel.getConnID()/CLIENT_MASK;
-        connections[clientID] = 0;
-        //removeAllSubscriptions(clientID);
-        cout << "wsserver: Closed connection " << connection->remote_endpoint_address() << " with status code " << status << endl;
+    // See RFC 6455 7.4.1. for status codes
+    vssEndpoint.on_close = [](shared_ptr<WsServer::Connection> connection,
+                              int status, const string & /*reason*/) {
+      uint32_t clientID = connection->channel.getConnID() / CLIENT_MASK;
+      connections[clientID] = 0;
+      // removeAllSubscriptions(clientID);
+      cout << "wsserver: Closed connection "
+           << connection->remote_endpoint_address() << " with status code "
+           << status << endl;
     };
 
-   // See http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html, Error Codes for error code meanings
-   vssEndpoint.on_error = [](shared_ptr<WsServer::Connection> connection, const SimpleWeb::error_code &ec) {
-        uint32_t clientID = connection->channel.getConnID()/CLIENT_MASK;
-        connections[clientID] = 0;
-        //removeAllSubscriptions(clientID);
-        cout << "wsserver: Error in connection " << connection->remote_endpoint_address()<<" with con ID "<< connection->channel.getConnID()<< ". "
-         << "Error: " << ec << ", error message: " << ec.message() << endl;
+    // See
+    // http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/reference.html,
+    // Error Codes for error code meanings
+    vssEndpoint.on_error = [](shared_ptr<WsServer::Connection> connection,
+                              const SimpleWeb::error_code &ec) {
+      uint32_t clientID = connection->channel.getConnID() / CLIENT_MASK;
+      connections[clientID] = 0;
+      // removeAllSubscriptions(clientID);
+      cout << "wsserver: Error in connection "
+           << connection->remote_endpoint_address() << " with con ID "
+           << connection->channel.getConnID() << ". "
+           << "Error: " << ec << ", error message: " << ec.message() << endl;
     };
 
-      cout << "started Insecure WS server" << endl; 
-      insecureServer->start();
-
-   
-   }
-   
+    cout << "started Insecure WS server" << endl;
+    insecureServer->start();
+  }
 }
 
 void wsserver::sendToConnection(uint32_t connectionID, string message) {
-    if( isSecure) {
+  if (isSecure) {
     auto send_stream = make_shared<WssServer::SendStream>();
-        *send_stream << message;
-        for(auto &a_connection : secureServer->get_connections()) {
-          if(a_connection->channel.getConnID() == connectionID){
-             a_connection->send(send_stream);
-             return;
-          }
+    *send_stream << message;
+    for (auto &a_connection : secureServer->get_connections()) {
+      if (a_connection->channel.getConnID() == connectionID) {
+        a_connection->send(send_stream);
+        return;
       }
-    }else {
-     auto send_stream = make_shared<WsServer::SendStream>();
-        *send_stream << message;
-        for(auto &a_connection : insecureServer->get_connections()) {
-          if(a_connection->channel.getConnID() == connectionID){
-             a_connection->send(send_stream);
-             return;
-          }
-      }
-
     }
+  } else {
+    auto send_stream = make_shared<WsServer::SendStream>();
+    *send_stream << message;
+    for (auto &a_connection : insecureServer->get_connections()) {
+      if (a_connection->channel.getConnID() == connectionID) {
+        a_connection->send(send_stream);
+        return;
+      }
+    }
+  }
 }
 
+void *startWSServer(void *arg) { wserver->startServer(""); }
 
-void* startWSServer(void * arg) {
-   
-   wserver->startServer("");
+void wsserver::start() {
+  this->database->initJsonTree();
+  pthread_t startWSServer_thread;
 
+  /* create the web socket server thread. */
+  if (pthread_create(&startWSServer_thread, NULL, &startWSServer, NULL)) {
+    cout << "main: Error creating websocket server run thread" << endl;
+  }
 }
-
-
-void wsserver::start()
-{
-        this->database->initJsonTree();
-        pthread_t startWSServer_thread;
-        
-        
-        /* create the web socket server thread. */
-        if(pthread_create(&startWSServer_thread, NULL, &startWSServer, NULL )) {
-         cout << "main: Error creating websocket server run thread"<<endl;
-
-        }
-
-}
-
-


### PR DESCRIPTION
Signed-off-by: John Argérus <john.argerus@se.bosch.com>

I've just started work on cleaning up w3c-visserver and migrating it and the dependant applications to the updated w3c format.

I thought I'd start with pushing this non-functionality-changing change, which just cleans up the formatting for elm-feeder and w3c-visserver.