### PR TITLE
Initial logging support instead of direct stdout in w3c-visserver-api

### DIFF
--- a/w3c-visserver-api/CMakeLists.txt
+++ b/w3c-visserver-api/CMakeLists.txt
@@ -114,6 +114,7 @@ if(UNIT_TEST)
          ${CMAKE_CURRENT_SOURCE_DIR}/src/subscriptionhandler.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/src/signing.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/src/wsserver.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/src/BasicLogger.cpp
          # ${CMAKE_CURRENT_SOURCE_DIR}/unit-test/vssdatabase_test.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/unit-test/w3cunittest.cpp
        )

--- a/w3c-visserver-api/CMakeLists.txt
+++ b/w3c-visserver-api/CMakeLists.txt
@@ -34,7 +34,7 @@ add_compile_options(-std=c++11 -pthread -Wall -Wextra -Werror)
 
 if ("${ADDRESS_SAN}" STREQUAL "ON" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
-  add_link_options(-g -fsanitize=address)
+  add_link_options(-g -fsanitize=address -ldl)
 endif()
 
 
@@ -61,7 +61,7 @@ set(Boost_USE_STATIC_LIBS ON)
 include_directories(${Boost_INCLUDE_DIRS})
 message(STATUS " boost includes ${Boost_INCLUDE_DIRS} ")
 
-find_package(Boost 1.58.0 COMPONENTS system thread program_options REQUIRED)
+find_package(Boost 1.64.0 COMPONENTS system thread program_options REQUIRED)
 
 target_link_libraries(simple-websocket-server INTERFACE ${Boost_LIBRARIES})
 target_include_directories(simple-websocket-server INTERFACE ${Boost_INCLUDE_DIR})

--- a/w3c-visserver-api/include/BasicLogger.hpp
+++ b/w3c-visserver-api/include/BasicLogger.hpp
@@ -1,0 +1,44 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2019 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH - initial API and functionality
+ * *****************************************************************************
+ */
+
+
+#ifndef __LOGGER_H__
+#define __LOGGER_H__
+
+#include "ILogger.hpp"
+
+#include <mutex>
+
+
+/**
+ * \class Logger
+ * \brief Implementation class of logging utility
+ *
+ * Logger shall provide standardized way to put logging information
+ * to standard output (stdout)
+ *
+ */
+class BasicLogger : public ILogger {
+  private:
+    std::mutex    accessMutex;
+    const uint8_t logLevels;
+
+  public:
+    BasicLogger(uint8_t logEventsEnabled);
+    ~BasicLogger();
+
+    void Log(LogLevel level, std::string logString);
+};
+
+#endif /* __LOGGER_H__ */

--- a/w3c-visserver-api/include/ILogger.hpp
+++ b/w3c-visserver-api/include/ILogger.hpp
@@ -1,0 +1,63 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2019 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH - initial API and functionality
+ * *****************************************************************************
+ */
+
+
+#ifndef __ILOGGER_H__
+#define __ILOGGER_H__
+
+#include <cstdint>
+#include <string>
+
+/**
+ * \class LogLevel
+ * \brief Supported logging levels
+ *
+ * Enumeration shall be used by implementations of \ref ILogger class to define
+ * which events to log.
+ * As enumeration is bitwise compatible, implementations can allow for combining
+ * different log levels (e.g. INFO & ERROR, other levels shall be ignored)
+ */
+enum class LogLevel : uint8_t {
+  NONE    = 0x0, //!< No logging allowed
+  VERBOSE = 0x1, //!< Used for logging verbose or debug information, not relevant in normal execution
+  INFO    = 0x2, //!< Used for logging e.g. positive information relevant to execution
+  WARNING = 0x4, //!< Used for logging warning states and information that is not critical
+  ERROR   = 0x8, //!< Used for logging any error or fail information
+  ALL     = 0xF  //!< Used for selecting all log levels
+};
+
+
+/**
+ * \class ILogger
+ * \brief Interface definition for logging utility
+ *
+ * Interface for logger allows to easily add support for logging through different
+ * means or requirements (e.g. resource scarce platforms, socket, serial, ...)
+ *
+ */
+class ILogger {
+  public:
+    virtual ~ILogger() {}
+
+    /**
+     * \brief Log message of specified notification level
+     *
+     * \param[in] Level of importance of log message
+     * \param[in] Log message
+     */
+    virtual void Log(LogLevel, std::string) = 0;
+
+};
+
+#endif /* __ILOGGER_H__ */

--- a/w3c-visserver-api/include/authenticator.hpp
+++ b/w3c-visserver-api/include/authenticator.hpp
@@ -14,21 +14,25 @@
 #ifndef __AUTHENTICATOR_H__
 #define __AUTHENTICATOR_H__
 
+#include <memory>
 #include <string>
 
 using namespace std;
 
 class wschannel;
 class vssdatabase;
+class ILogger;
 
 class authenticator {
  private:
   string pubkey = "secret";
   string algorithm = "RS256";
+  std::shared_ptr<ILogger> logger;
+
   int validateToken(wschannel& channel, string authToken);
 
  public:
-  authenticator(string secretkey, string algorithm);
+  authenticator(std::shared_ptr<ILogger> loggerUtil, string secretkey, string algorithm);
   int validate(wschannel &channel, vssdatabase *database,
                string authToken);
   

--- a/w3c-visserver-api/include/permmclient.hpp
+++ b/w3c-visserver-api/include/permmclient.hpp
@@ -16,11 +16,14 @@
 #define __PERMMCLIENT_H__
 
 #include <jsoncons/json.hpp>
+#include <memory>
 
 using namespace std;
 using namespace jsoncons;
 
-json getPermToken(string clientName, string clientSecret);
+class ILogger;
+
+json getPermToken(std::shared_ptr<ILogger> logger, string clientName, string clientSecret);
 
 
 

--- a/w3c-visserver-api/include/signing.hpp
+++ b/w3c-visserver-api/include/signing.hpp
@@ -20,18 +20,23 @@
 #include <iostream>
 #include <jsoncons/json.hpp>
 
+#include <memory>
+
 using namespace std;
 using namespace jsoncons;
 using namespace jwt;
 
+class ILogger;
+
 class signing {
  private:
+  std::shared_ptr<ILogger> logger;
   string key = "";
   string pubkey = "";
   string algorithm = "RS256";
 
  public:
-  signing();
+  signing(std::shared_ptr<ILogger> loggerUtil);
   string getKey(string fileName);
   string getPublicKey(string fileName);
   string sign(json data);

--- a/w3c-visserver-api/include/subscriptionhandler.hpp
+++ b/w3c-visserver-api/include/subscriptionhandler.hpp
@@ -20,6 +20,7 @@
 #include "visconf.hpp"
 #include <string>
 #include <thread>
+#include <memory>
 
 #include <jsoncons/json.hpp>
 
@@ -28,6 +29,7 @@ class authenticator;
 class vssdatabase;
 class wschannel;
 class wsserver;
+class ILogger;
 
 // Subscription ID: Client ID
 typedef std::unordered_map<uint32_t, uint32_t> subscriptions_t;
@@ -37,6 +39,7 @@ typedef std::string uuid_t;
 
 class subscriptionhandler {
  private:
+  std::shared_ptr<ILogger> logger;
   std::unordered_map<uuid_t, subscriptions_t> subscribeHandle;
   wsserver* server;
   authenticator* validator;
@@ -47,7 +50,8 @@ class subscriptionhandler {
   std::queue<std::pair<uint32_t, jsoncons::json>> buffer;
 
  public:
-  subscriptionhandler(wsserver* wserver,
+  subscriptionhandler(std::shared_ptr<ILogger> loggerUtil,
+                      wsserver* wserver,
                       authenticator* authenticate,
                       accesschecker* checkAccess);
   ~subscriptionhandler();

--- a/w3c-visserver-api/include/vsscommandprocessor.hpp
+++ b/w3c-visserver-api/include/vsscommandprocessor.hpp
@@ -15,6 +15,7 @@
 #define __VSSCOMMANDPROCESSOR_H__
 
 #include <string>
+#include <memory>
 
 #include <jsoncons/json.hpp>
 
@@ -23,9 +24,11 @@ class subscriptionhandler;
 class authenticator;
 class accesschecker;
 class wschannel;
+class ILogger;
 
 class vsscommandprocessor {
  private:
+  std::shared_ptr<ILogger> logger;
   vssdatabase* database = NULL;
   subscriptionhandler* subHandler = NULL;
   authenticator* tokenValidator = NULL;
@@ -48,7 +51,9 @@ class vsscommandprocessor {
   
 
  public:
-  vsscommandprocessor(vssdatabase* database, authenticator* vdator,
+  vsscommandprocessor(std::shared_ptr<ILogger> loggerUtil,
+                      vssdatabase* database,
+                      authenticator* vdator,
                       subscriptionhandler* subhandler);
   ~vsscommandprocessor();
   std::string processQuery(std::string req_json, wschannel& channel);

--- a/w3c-visserver-api/include/vssdatabase.hpp
+++ b/w3c-visserver-api/include/vssdatabase.hpp
@@ -17,12 +17,14 @@
 #include <string>
 #include <list>
 #include <mutex>
+#include <memory>
 
 #include <jsoncons/json.hpp>
 
 class subscriptionhandler;
 class accesschecker;
 class wschannel;
+class ILogger;
 
 class vssdatabase {
   friend class subscriptionhandler;
@@ -32,6 +34,7 @@ class vssdatabase {
 #endif
 
  private:
+  std::shared_ptr<ILogger> logger;
   std::mutex rwMutex;
   jsoncons::json data_tree;
   jsoncons::json meta_tree;
@@ -45,7 +48,8 @@ class vssdatabase {
   void checkSetPermission(wschannel& channel, jsoncons::json valueJson);
 
  public:
-  vssdatabase(subscriptionhandler* subHandle,
+  vssdatabase(std::shared_ptr<ILogger> loggerUtil,
+              subscriptionhandler* subHandle,
               accesschecker* accValidator);
   ~vssdatabase();
   void initJsonTree(std::string fileName);

--- a/w3c-visserver-api/include/wsserver.hpp
+++ b/w3c-visserver-api/include/wsserver.hpp
@@ -17,7 +17,6 @@
 
 #include "server_wss.hpp"
 
-#include "ILogger.hpp"
 
 class vsscommandprocessor;
 class vsscommandprocessor;
@@ -25,6 +24,7 @@ class subscriptionhandler;
 class authenticator;
 class vssdatabase;
 class accesschecker;
+class ILogger;
 
 class wsserver {
  private:
@@ -41,7 +41,7 @@ class wsserver {
   vssdatabase* database;
   accesschecker* accessCheck;
 
-  wsserver(int port, std::string configFileName, bool secure, std::shared_ptr<ILogger> loggerUtil);
+  wsserver(std::shared_ptr<ILogger> loggerUtil, int port, std::string configFileName, bool secure);
   ~wsserver();
   void startServer(std::string endpointName);
   void sendToConnection(uint32_t connID, std::string message);

--- a/w3c-visserver-api/include/wsserver.hpp
+++ b/w3c-visserver-api/include/wsserver.hpp
@@ -17,6 +17,8 @@
 
 #include "server_wss.hpp"
 
+#include "ILogger.hpp"
+
 class vsscommandprocessor;
 class vsscommandprocessor;
 class subscriptionhandler;
@@ -28,6 +30,7 @@ class wsserver {
  private:
   SimpleWeb::SocketServer<SimpleWeb::WSS> *secureServer_;
   SimpleWeb::SocketServer<SimpleWeb::WS> *insecureServer_;
+  std::shared_ptr<ILogger> logger;
   bool isSecure_;
   std::string configFileName_;
 
@@ -38,7 +41,7 @@ class wsserver {
   vssdatabase* database;
   accesschecker* accessCheck;
 
-  wsserver(int port, std::string configFileName, bool secure);
+  wsserver(int port, std::string configFileName, bool secure, std::shared_ptr<ILogger> loggerUtil);
   ~wsserver();
   void startServer(std::string endpointName);
   void sendToConnection(uint32_t connID, std::string message);

--- a/w3c-visserver-api/src/BasicLogger.cpp
+++ b/w3c-visserver-api/src/BasicLogger.cpp
@@ -1,0 +1,63 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2019 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH - initial API and functionality
+ * *****************************************************************************
+ */
+
+#include "BasicLogger.hpp"
+
+#include <iostream>
+
+
+using namespace std;
+
+namespace {
+  std::string GetLevelString(LogLevel level) {
+    std::string retStr;
+    switch (level) {
+    case LogLevel::VERBOSE:
+      retStr = "VERBOSE: ";
+      break;
+    case LogLevel::INFO:
+      retStr = "INFO: ";
+      break;
+    case LogLevel::WARNING:
+      retStr = "WARNING: ";
+      break;
+    case LogLevel::ERROR:
+      retStr = "ERROR: ";
+      break;
+    default:
+      retStr = "UNKNOWN: ";
+      break;
+    }
+    return retStr;
+  }
+}
+
+
+BasicLogger::BasicLogger(uint8_t logEventsEnabled) : logLevels(logEventsEnabled) {
+  cout << "Log START" << endl;
+}
+
+
+BasicLogger::~BasicLogger() {
+  cout << "Log END" << endl;
+}
+
+void BasicLogger::Log(LogLevel level, std::string logString) {
+  std::lock_guard<std::mutex> guard(accessMutex);
+
+  /* log only if level in supported */
+  if (static_cast<uint8_t>(level) & logLevels) {
+    cout << GetLevelString(level) + logString << endl;
+  }
+}

--- a/w3c-visserver-api/src/authenticator.cpp
+++ b/w3c-visserver-api/src/authenticator.cpp
@@ -51,7 +51,7 @@ int authenticator::validateToken(wschannel& channel, string authToken) {
   json claims;
   (void) channel;
   for (auto& e : decoded.get_payload_claims()) {
-    std::cout << e.first << " = " << e.second.to_json() << std::endl;
+    logger->Log(LogLevel::INFO, e.first + " = " + e.second.as_string());
     claims[e.first] = e.second.to_json().to_str();
   }
   

--- a/w3c-visserver-api/src/permmclient.cpp
+++ b/w3c-visserver-api/src/permmclient.cpp
@@ -22,12 +22,13 @@
 
 #include "exception.hpp"
 #include "permmclient.hpp"
+#include "ILogger.hpp"
 
 using namespace std;
 
 #define SERVER "/home/pratheek/socket/kuksa_w3c_perm_management"
 
-json getPermToken(string clientName, string clientSecret) {
+json getPermToken(std::shared_ptr<ILogger> logger, string clientName, string clientSecret) {
 
   // Open unix socket connection.
    struct sockaddr_un addr;
@@ -35,7 +36,7 @@ json getPermToken(string clientName, string clientSecret) {
    
    if ( (fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
       throw genException("Unable to create a unix socket");
-      //cout <<"Unable to create a unix socket"<<endl;
+      //logger->Log(LogLevel::ERROR, "Unable to create a unix socket");
    }
 
    memset(&addr, 0, sizeof(addr));
@@ -45,7 +46,7 @@ json getPermToken(string clientName, string clientSecret) {
 
    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
       throw genException("Unable to connect to server");
-      //cout <<"Unable to connect to server"<<endl;
+      //logger->Log(LogLevel::ERROR, "Unable to connect to server");
    }
 
    
@@ -59,15 +60,15 @@ json getPermToken(string clientName, string clientSecret) {
    int length = request.length();
    // Send and wait for response from the permmanagent daemon.
    if(write(fd, request.c_str(), length) != length) {
-      cout << "Request not sent completely" <<endl;
+     logger->Log(LogLevel::ERROR, "Request not sent completely");
    } else {
-      cout << "Request sent " <<endl;
+     logger->Log(LogLevel::INFO, "Request sent ");
    }
    
    char response_buf[1024 * 10] = {0};
    read(fd, response_buf, sizeof(response_buf));
 
-   cout << "Response read from server "<<endl;
+   logger->Log(LogLevel::INFO, "Response read from server ");
 
    string response(response_buf); 
    jsoncons::json respJson = jsoncons::json::parse(response);

--- a/w3c-visserver-api/src/signing.cpp
+++ b/w3c-visserver-api/src/signing.cpp
@@ -14,13 +14,15 @@
 
 #include "signing.hpp"
 
+#include "ILogger.hpp"
+
 #define PRIVATEFILENAME "signing.private.key"
 #define PUBLICFILENAME "signing.public.key"
 
 /**
  Constructor
 */
-signing::signing() {
+signing::signing(std::shared_ptr<ILogger> loggerUtil) : logger(loggerUtil) {
   getKey(PRIVATEFILENAME);
   getPublicKey(PUBLICFILENAME);
 }
@@ -104,7 +106,7 @@ string signing::decode(string signedData) {
   try {
     verify.verify(decoded_token);
   } catch (exception& e) {
-    cout << "Error while verfying JSON signing " << e.what() << endl;
+    logger->Log(LogLevel::ERROR, "Error while verifying JSON signing " + string(e.what()));
     return "";
   }
 

--- a/w3c-visserver-api/src/vsscommandprocessor.cpp
+++ b/w3c-visserver-api/src/vsscommandprocessor.cpp
@@ -308,9 +308,9 @@ string vsscommandprocessor::processAuthorizeWithPermManager(wschannel &channel,
   jsoncons::json response;
   // Get Token from permission management daemon.
   try {
-     response = getPermToken(client, clientSecret);
+     response = getPermToken(logger, client, clientSecret);
   } catch (genException &exp) {
-    cout << exp.what() << endl;
+    logger->Log(LogLevel::ERROR, exp.what());
     jsoncons::json result;
     jsoncons::json error;
     result["action"] = "kuksa-authorize";
@@ -332,7 +332,7 @@ string vsscommandprocessor::processAuthorizeWithPermManager(wschannel &channel,
         tokenValidator->updatePubKey(response["pubkey"].as<string>());
         ttl = tokenValidator->validate(channel, database, response["token"].as<string>());
      } catch (exception &e) {
-        cout << e.what() << endl;
+        logger->Log(LogLevel::ERROR, e.what());
         ttl = -1;
      }
   }
@@ -429,8 +429,8 @@ string vsscommandprocessor::processQuery(string req_json,
       string clientSecret = root["secret"].as<string>();
       uint32_t request_id = root["requestId"].as<int>();
 #ifdef DEBUG
-      cout << "vsscommandprocessor::processQuery: kuksa authorize query with clientID = "
-           << clientID << " with secret " << clientSecret << endl;
+      logger->Log(LogLevel::VERBOSE, "vsscommandprocessor::processQuery: kuksa authorize query with clientID = "
+           + clientID + " with secret " + clientSecret);
 #endif
       response = processAuthorizeWithPermManager(channel, request_id, clientID, clientSecret);
     } else {

--- a/w3c-visserver-api/src/vssdatabase.cpp
+++ b/w3c-visserver-api/src/vssdatabase.cpp
@@ -511,8 +511,8 @@ void vssdatabase::setSignal(wschannel& channel, string path,
       jsoncons::json item = setValues[i];
       string jPath = item["path"].as<string>();
 #ifdef DEBUG
-      cout << "vssdatabase::setSignal: path found = " << jPath << endl;
-      cout << "value to set asstring = " << item["value"].as<string>() << endl;
+      logger->Log(LogLevel::VERBOSE, "vssdatabase::setSignal: path found = " + jPath);
+      logger->Log(LogLevel::VERBOSE, "value to set asstring = " + item["value"].as<string>());
 #endif
       rwMutex.lock();
       jsoncons::json resArray = json_query(data_tree, jPath);
@@ -530,8 +530,7 @@ void vssdatabase::setSignal(wschannel& channel, string path,
           json_replace(data_tree, jPath, resJson);
           rwMutex.unlock();
 #ifdef DEBUG
-          cout << "vssdatabase::setSignal: new value set at path " << jPath
-               << endl;
+          logger->Log(LogLevel::VERBOSE, "vssdatabase::setSignal: new value set at path " + jPath);
 #endif
 
           string uuid = resJson["uuid"].as<string>();
@@ -545,12 +544,10 @@ void vssdatabase::setSignal(wschannel& channel, string path,
         }
 
       } else if (resArray.is_array()) {
-        cout << "vssdatabase::setSignal : Path " << jPath << " has "
-             << resArray.size() << " signals, the path needs refinement"
-             << endl;
         stringstream msg;
         msg << "Path " << jPath << " has " << resArray.size()
             << " signals, the path needs refinement";
+        logger->Log(LogLevel::INFO, "vssdatabase::setSignal : " + msg.str());
         throw genException(msg.str());
       }
     }
@@ -621,18 +618,6 @@ void vssdatabase::setSignal(string path,
     logger->Log(LogLevel::ERROR, "vssdatabase::setSignal: " + msg);
     throw genException(msg);
   }
-}
-
-// Utility method for setting values to JSON.
-void setJsonValue(jsoncons::json& dest, jsoncons::json& source, string key) {
-  if (!source.has_key("type")) {
-    cout << "vssdatabase::setJsonValue : could not set value! type is not "
-            "present in source json!"
-         << endl;
-    string msg = "Unknown type for signal found at " + key;
-    throw genException(msg);
-  }
-  dest[key] = source["value"];
 }
 
 // Returns response JSON for get request.

--- a/w3c-visserver-api/src/wsserver.cpp
+++ b/w3c-visserver-api/src/wsserver.cpp
@@ -62,7 +62,7 @@ wsserver::wsserver(std::shared_ptr<ILogger> loggerUtil, int port, string configF
   accessCheck = new accesschecker(tokenValidator);
   subHandler = new subscriptionhandler(logger, this, tokenValidator, accessCheck);
   database = new vssdatabase(subHandler, accessCheck);
-  cmdProcessor = new vsscommandprocessor(database, tokenValidator, subHandler);
+  cmdProcessor = new vsscommandprocessor(logger, database, tokenValidator, subHandler);
   wserver = this;
 }
 

--- a/w3c-visserver-api/src/wsserver.cpp
+++ b/w3c-visserver-api/src/wsserver.cpp
@@ -61,7 +61,7 @@ wsserver::wsserver(std::shared_ptr<ILogger> loggerUtil, int port, string configF
   tokenValidator = new authenticator(logger, "appstacle", "RS256");
   accessCheck = new accesschecker(tokenValidator);
   subHandler = new subscriptionhandler(logger, this, tokenValidator, accessCheck);
-  database = new vssdatabase(subHandler, accessCheck);
+  database = new vssdatabase(logger, subHandler, accessCheck);
   cmdProcessor = new vsscommandprocessor(logger, database, tokenValidator, subHandler);
   wserver = this;
 }

--- a/w3c-visserver-api/src/wsserver.cpp
+++ b/w3c-visserver-api/src/wsserver.cpp
@@ -60,7 +60,7 @@ wsserver::wsserver(std::shared_ptr<ILogger> loggerUtil, int port, string configF
 
   tokenValidator = new authenticator(logger, "appstacle", "RS256");
   accessCheck = new accesschecker(tokenValidator);
-  subHandler = new subscriptionhandler(this, tokenValidator, accessCheck);
+  subHandler = new subscriptionhandler(logger, this, tokenValidator, accessCheck);
   database = new vssdatabase(subHandler, accessCheck);
   cmdProcessor = new vsscommandprocessor(database, tokenValidator, subHandler);
   wserver = this;

--- a/w3c-visserver-api/src/wsserver.cpp
+++ b/w3c-visserver-api/src/wsserver.cpp
@@ -58,7 +58,7 @@ wsserver::wsserver(std::shared_ptr<ILogger> loggerUtil, int port, string configF
     insecureServer_->config.port = port;
   }
 
-  tokenValidator = new authenticator("appstacle", "RS256");
+  tokenValidator = new authenticator(logger, "appstacle", "RS256");
   accessCheck = new accesschecker(tokenValidator);
   subHandler = new subscriptionhandler(this, tokenValidator, accessCheck);
   database = new vssdatabase(subHandler, accessCheck);


### PR DESCRIPTION
Added initial logging interface and basic implementation of it. It will allow in future to easily swap logging implementations, depending on platform specifics.

This is also initial work to break existing classes in smaller components with clear dependencies for easier unit testing later. 

Existing tests are more of integration level and have dependency between.

Updated Boost version dependency to 1.67 as it compiles without any error or warning